### PR TITLE
feat: add vanRossem preview UPLC builds for issue #180

### DIFF
--- a/src/factorial_naive_recursion/FactorialNaiveRecursion.scala
+++ b/src/factorial_naive_recursion/FactorialNaiveRecursion.scala
@@ -2,6 +2,7 @@ package factorial_naive_recursion
 
 import common.Util
 import scalus.*
+import scalus.cardano.ledger.MajorProtocolVersion
 import scalus.compiler.{Compile, compile, Options}
 import scalus.uplc.eval.PlutusVM
 
@@ -20,10 +21,22 @@ object FactorialNaiveRecursion:
 
 @main def compileFactorialNaiveRecursion(): Unit =
   // Compile the parameterized factorial function to UPLC Program
-  val program = common.Renamer.rename(
-    compile(FactorialNaiveRecursion.factorial).toUplcOptimized(using Options.release)().plutusV3
-  )
+  val sir = compile(FactorialNaiveRecursion.factorial)
 
-  given PlutusVM = PlutusVM.makePlutusV3VM()
-  Util.assertEvaluatesTo(program, input = 10, expected = 3628800)
+  val program = common.Renamer.rename(sir.toUplcOptimized(using Options.release)().plutusV3)
+  locally:
+    given PlutusVM = PlutusVM.makePlutusV3VM()
+    Util.assertEvaluatesTo(program, input = 10, expected = 3628800)
   Util.writeUplc("factorial_naive_recursion", "factorial.uplc", program.pretty.render(80))
+
+  // vanRossem preview build (case-on-builtins, batch6, dropList)
+  val vanRossem = Options.release.copy(targetProtocolVersion = MajorProtocolVersion.vanRossemPV)
+  val programVR = common.Renamer.rename(sir.toUplcOptimized(using vanRossem)().plutusV3)
+  locally:
+    given PlutusVM = PlutusVM.makePlutusV3VM(MajorProtocolVersion.vanRossemPV)
+    Util.assertEvaluatesTo(programVR, input = 10, expected = 3628800)
+  Util.writeUplc(
+    "factorial_naive_recursion",
+    "factorial-vanrossem.uplc",
+    programVR.pretty.render(80)
+  )

--- a/src/factorial_naive_recursion/factorial-vanrossem.uplc
+++ b/src/factorial_naive_recursion/factorial-vanrossem.uplc
@@ -1,0 +1,7 @@
+(program 1.1.0 [(lam a
+      [(lam b [a (lam c [b b c])]) (lam b [a (lam c [b b c])])]) (lam d
+      (lam e
+        (case [(builtin lessThanEqualsInteger) e
+            (con integer 0)] [(builtin multiplyInteger) e [d
+              [(builtin subtractInteger) e (con integer 1)]]]
+          (con integer 1))))])

--- a/src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala
+++ b/src/fibonacci_naive_recursion/FibonacciNaiveRecursion.scala
@@ -2,6 +2,7 @@ package fibonacci_naive_recursion
 
 import common.Util
 import scalus.*
+import scalus.cardano.ledger.MajorProtocolVersion
 import scalus.compiler.{Compile, compile, Options}
 import scalus.uplc.Term.asTerm
 import scalus.uplc.eval.*
@@ -22,10 +23,22 @@ object FibonacciNaiveRecursion:
 
 @main def compileFibonacciNaiveRecursion(): Unit =
     // Compile the parameterized fibonacci function to UPLC Program
-    val program = common.Renamer.rename(
-        compile(FibonacciNaiveRecursion.fibonacci).toUplcOptimized(using Options.release)().plutusV3
-    )
+    val sir = compile(FibonacciNaiveRecursion.fibonacci)
 
-    given PlutusVM = PlutusVM.makePlutusV3VM()
-    Util.assertEvaluatesTo(program, input = 10, expected = 55)
+    val program = common.Renamer.rename(sir.toUplcOptimized(using Options.release)().plutusV3)
+    locally:
+        given PlutusVM = PlutusVM.makePlutusV3VM()
+        Util.assertEvaluatesTo(program, input = 10, expected = 55)
     Util.writeUplc("fibonacci_naive_recursion", "fibonacci.uplc", program.pretty.render(80))
+
+    // vanRossem preview build (case-on-builtins, batch6, dropList)
+    val vanRossem    = Options.release.copy(targetProtocolVersion = MajorProtocolVersion.vanRossemPV)
+    val programVR    = common.Renamer.rename(sir.toUplcOptimized(using vanRossem)().plutusV3)
+    locally:
+        given PlutusVM = PlutusVM.makePlutusV3VM(MajorProtocolVersion.vanRossemPV)
+        Util.assertEvaluatesTo(programVR, input = 10, expected = 55)
+    Util.writeUplc(
+      "fibonacci_naive_recursion",
+      "fibonacci-vanrossem.uplc",
+      programVR.pretty.render(80)
+    )

--- a/src/fibonacci_naive_recursion/fibonacci-vanrossem.uplc
+++ b/src/fibonacci_naive_recursion/fibonacci-vanrossem.uplc
@@ -1,0 +1,9 @@
+(program 1.1.0 [(lam a
+      [(lam b [a (lam c [b b c])]) (lam b [a (lam c [b b c])])]) (lam d
+      (lam e
+        (case [(builtin lessThanEqualsInteger) e
+            (con integer 1)] (case [(builtin equalsInteger) e
+              (con integer 2)] [(builtin addInteger) [d
+                [(builtin subtractInteger) e (con integer 1)]] [d
+                [(builtin subtractInteger) e (con integer 2)]]] (con integer 1))
+          e)))])

--- a/src/fibonacci_prepacked/FibonacciPrepacked.scala
+++ b/src/fibonacci_prepacked/FibonacciPrepacked.scala
@@ -2,6 +2,7 @@ package fibonacci_prepacked
 
 import common.Util
 import scalus.*
+import scalus.cardano.ledger.MajorProtocolVersion
 import scalus.compiler.compile
 import scalus.compiler.Options
 import scalus.uplc.builtin.Builtins.*
@@ -52,13 +53,25 @@ val packedFibonacci = fibSeqByteString(26)
           if x <= BigInt(0) then x
           else byteStringToInteger(true, sliceByteString(x * 3, 3, packedFibonacci))
 
-  // Apply the packed fibonacci ByteString
-  val fibTerm = fib.toUplc(using Options.release)() $ packedFibonacci.asTerm
+  def buildProgram(opts: Options): Program =
+      val term      = fib.toUplc(using opts)() $ packedFibonacci.asTerm
+      val optimized = term |> Inliner.apply |> CaseConstrApply.apply
+      common.Renamer.rename(optimized.plutusV3)
 
-  // Optimize the term by inlining the constant ByteString
-  val optimized = fibTerm |> Inliner.apply |> CaseConstrApply.apply
-  val program = common.Renamer.rename(optimized.plutusV3)
-
-  given PlutusVM = PlutusVM.makePlutusV3VM()
-  Util.assertEvaluatesTo(program, input = 10, expected = 55)
+  val program = buildProgram(Options.release)
+  locally:
+      given PlutusVM = PlutusVM.makePlutusV3VM()
+      Util.assertEvaluatesTo(program, input = 10, expected = 55)
   Util.writeUplc("fibonacci_prepacked", "fibonacci.uplc", program.pretty.render(80))
+
+  // vanRossem preview build (case-on-builtins, batch6, dropList)
+  val vanRossem = Options.release.copy(targetProtocolVersion = MajorProtocolVersion.vanRossemPV)
+  val programVR = buildProgram(vanRossem)
+  locally:
+      given PlutusVM = PlutusVM.makePlutusV3VM(MajorProtocolVersion.vanRossemPV)
+      Util.assertEvaluatesTo(programVR, input = 10, expected = 55)
+  Util.writeUplc(
+    "fibonacci_prepacked",
+    "fibonacci-vanrossem.uplc",
+    programVR.pretty.render(80)
+  )

--- a/src/fibonacci_prepacked/fibonacci-vanrossem.uplc
+++ b/src/fibonacci_prepacked/fibonacci-vanrossem.uplc
@@ -1,0 +1,7 @@
+(program 1.1.0 (lam a
+    (case [(builtin lessThanEqualsInteger) a
+        (con integer 0)] [(builtin byteStringToInteger) (con bool True)
+        (case (constr 0 [(builtin multiplyInteger) a (con integer 3)]
+            (con integer 3)
+            (con bytestring #00000000000100000100000200000300000500000800000d0000150000220000370000590000900000e90001790002620003db00063d000a18001055001a6d002ac200452f006ff100b520012511)) (builtin sliceByteString))]
+      a)))

--- a/src/htlc/HTLC.scala
+++ b/src/htlc/HTLC.scala
@@ -2,6 +2,7 @@ package htlc
 
 import common.Util
 import scalus.*
+import scalus.cardano.ledger.MajorProtocolVersion
 import scalus.compiler.{Compile, compile, Options}
 import scalus.uplc.builtin.*
 import scalus.uplc.builtin.Builtins.sha2_256
@@ -128,6 +129,19 @@ enum HTLCRedeemer derives FromData, ToData:
             case None    => fail(OwnInputNotFound)
 
 @main def compileHtlc(): Unit =
-    val raw = compile(HtlcValidator.validate).toUplcOptimized(using Options.release)().plutusV3
-    val program = common.Renamer.rename(raw)
+    val sir = compile(HtlcValidator.validate)
+
+    val program = common.Renamer.rename(
+      sir.toUplcOptimized(using Options.release)().plutusV3
+    )
     Util.writeUplc("htlc", "htlc.uplc", program.pretty.render(80))
+
+    // vanRossem preview build (case-on-builtins, batch6, dropList)
+    val vanRossem = Options.release.copy(targetProtocolVersion = MajorProtocolVersion.vanRossemPV)
+    val programVR = common.Renamer.rename(
+      sir.toUplcOptimized(using vanRossem)().plutusV3
+    )
+    Util.writeUplc("htlc", "htlc-vanrossem.uplc", programVR.pretty.render(80))
+
+    // Sanity-eval both variants on Claim and Refund redeemers against minimal ScriptContexts.
+    HtlcHarness.checkBoth(program, programVR)

--- a/src/htlc/HtlcHarness.scala
+++ b/src/htlc/HtlcHarness.scala
@@ -1,0 +1,135 @@
+package htlc
+
+import scalus.cardano.ledger.MajorProtocolVersion
+import scalus.cardano.onchain.plutus.prelude.{List as PList, Option as POption, SortedMap}
+import scalus.cardano.onchain.plutus.v1.{
+    Address,
+    Credential,
+    Interval,
+    IntervalBound,
+    IntervalBoundType,
+    PubKeyHash,
+    Value
+}
+import scalus.cardano.onchain.plutus.v2.{OutputDatum, TxOut}
+import scalus.cardano.onchain.plutus.v3.{
+    ScriptContext,
+    ScriptInfo,
+    TxId,
+    TxInInfo,
+    TxInfo,
+    TxOutRef
+}
+import scalus.uplc.builtin.{ByteString, Builtins, Data, ToData}
+import scalus.uplc.eval.{PlutusVM, Result}
+import scalus.uplc.{Constant, Program, Term}
+
+/** Off-chain harness to evaluate the HTLC validator on a minimal `ScriptContext`
+  * for both `Claim` and `Refund` redeemers, against `changPV` and `vanRossemPV`.
+  *
+  * The context is constructed with empty defaults for any field the validator
+  * does not read (governance, mint, certificates, redeemers map, etc.).
+  */
+object HtlcHarness:
+
+    private val zero32 =
+        ByteString.fromHex("0000000000000000000000000000000000000000000000000000000000000000")
+    private val payerPkh28     = ByteString.fromHex("00" * 28)
+    private val recipientPkh28 = ByteString.fromHex("11" * 28)
+    private val scriptHash28   = ByteString.fromHex("22" * 28)
+    private val preimage       = ByteString.fromString("htlc-preimage")
+    private val secretHash     = Builtins.sha2_256(preimage)
+
+    private val timeout: BigInt = BigInt(1000)
+
+    private val payerAddr     = Address(Credential.PubKeyCredential(PubKeyHash(payerPkh28)), POption.None)
+    private val recipientAddr = Address(Credential.PubKeyCredential(PubKeyHash(recipientPkh28)), POption.None)
+    private val ownAddr       = Address(Credential.ScriptCredential(scriptHash28), POption.None)
+
+    private val ownRef = TxOutRef(TxId(zero32), BigInt(0))
+    private val ownInput =
+        TxInInfo(ownRef, TxOut(ownAddr, Value.zero, OutputDatum.NoOutputDatum, POption.None))
+
+    private val datum = HTLCDatum(
+      payer = payerAddr,
+      recipient = recipientAddr,
+      secretHash = secretHash,
+      timeout = timeout
+    )
+
+    // Claim is allowed iff upper bound (exclusive) < timeout.
+    private val claimValidRange = Interval(
+      from = IntervalBound(IntervalBoundType.NegInf, isInclusive = true),
+      to = IntervalBound(IntervalBoundType.Finite(timeout - 1), isInclusive = true)
+    )
+
+    // Refund is allowed iff lower bound (inclusive) > timeout.
+    private val refundValidRange = Interval(
+      from = IntervalBound(IntervalBoundType.Finite(timeout + 1), isInclusive = true),
+      to = IntervalBound(IntervalBoundType.PosInf, isInclusive = true)
+    )
+
+    private def mkTxInfo(signer: ByteString, validRange: Interval): TxInfo = TxInfo(
+      inputs = PList.Cons(ownInput, PList.Nil),
+      referenceInputs = PList.Nil,
+      outputs = PList.Nil,
+      fee = BigInt(0),
+      mint = Value.zero,
+      certificates = PList.Nil,
+      withdrawals = SortedMap.empty,
+      validRange = validRange,
+      signatories = PList.Cons(PubKeyHash(signer), PList.Nil),
+      redeemers = SortedMap.empty,
+      data = SortedMap.empty,
+      id = TxId(zero32),
+      votes = SortedMap.empty,
+      proposalProcedures = PList.Nil,
+      currentTreasuryAmount = POption.None,
+      treasuryDonation = POption.None
+    )
+
+    private val datumData: Data = summon[ToData[HTLCDatum]].apply(datum)
+    private val spendingScriptInfo: ScriptInfo =
+        ScriptInfo.SpendingScript(ownRef, POption.Some(datumData))
+
+    private val claimRedeemerData: Data =
+        summon[ToData[HTLCRedeemer]].apply(HTLCRedeemer.Claim(preimage))
+    private val refundRedeemerData: Data =
+        summon[ToData[HTLCRedeemer]].apply(HTLCRedeemer.Refund)
+
+    private val claimContext: ScriptContext = ScriptContext(
+      txInfo = mkTxInfo(recipientPkh28, claimValidRange),
+      redeemer = claimRedeemerData,
+      scriptInfo = spendingScriptInfo
+    )
+    private val refundContext: ScriptContext = ScriptContext(
+      txInfo = mkTxInfo(payerPkh28, refundValidRange),
+      redeemer = refundRedeemerData,
+      scriptInfo = spendingScriptInfo
+    )
+
+    private def asTerm(d: Data): Term = Term.Const(Constant.Data(d))
+
+    private val ctxToData: ToData[ScriptContext] = summon[ToData[ScriptContext]]
+    private val claimCtxTerm  = asTerm(ctxToData.apply(claimContext))
+    private val refundCtxTerm = asTerm(ctxToData.apply(refundContext))
+
+    /** Evaluate `program` on the Claim and Refund contexts using the given VM. */
+    def check(label: String, program: Program)(using PlutusVM): Unit =
+        for (variant, term) <- Seq("claim" -> claimCtxTerm, "refund" -> refundCtxTerm) do
+            (program $ term).term.evaluateDebug match
+                case Result.Success(_, budget, _, _) =>
+                    println(
+                      s"✓ htlc/$label/$variant  cpu=${budget.steps} mem=${budget.memory}"
+                    )
+                case Result.Failure(ex, _, _, _) =>
+                    sys.error(s"htlc/$label/$variant evaluation failed: $ex")
+
+    /** Evaluate both the changPV (`program`) and vanRossemPV (`programVR`) builds. */
+    def checkBoth(program: Program, programVR: Program): Unit =
+        locally:
+            given PlutusVM = PlutusVM.makePlutusV3VM()
+            check("changPV  ", program)
+        locally:
+            given PlutusVM = PlutusVM.makePlutusV3VM(MajorProtocolVersion.vanRossemPV)
+            check("vanRossem", programVR)

--- a/src/htlc/htlc-vanrossem.uplc
+++ b/src/htlc/htlc-vanrossem.uplc
@@ -1,0 +1,304 @@
+(program 1.1.0 (case (constr 0 (force (builtin dropList))
+      (force (force (builtin fstPair))) (force (builtin headList))
+      (force (builtin mkCons)) (force (force (builtin sndPair)))
+      (force (builtin tailList))) (lam a
+      (lam b
+        (lam c
+          (lam d
+            (lam e
+              (lam f
+                [(lam g
+                    [(lam h
+                        [(lam i
+                            [(lam j
+                                [(lam k
+                                    [(lam l
+                                        [(lam m
+                                            (lam n
+                                              [(lam o
+                                                  [(lam p
+                                                      [(lam q
+                                                          (case [b q] (error)
+                                                            [(lam r
+                                                                [(lam s
+                                                                    [(lam t
+                                                                        [(lam u
+                                                                            [(lam v
+                                                                                (case [b
+                                                                                    t] (case (constr 0 [e
+                                                                                        [(builtin unConstrData)
+                                                                                          [c
+                                                                                            o]]]
+                                                                                      [e
+                                                                                        [(builtin unConstrData)
+                                                                                          [c
+                                                                                            r]]]
+                                                                                      s
+                                                                                      [(builtin unBData)
+                                                                                        [c
+                                                                                          [e
+                                                                                            t]]]) (lam w
+                                                                                      (lam x
+                                                                                        (lam y
+                                                                                          (lam z
+                                                                                            [(lam aa
+                                                                                                [(lam ab
+                                                                                                    [(lam ac
+                                                                                                        (case [(builtin equalsInteger)
+                                                                                                            [(builtin unIData)
+                                                                                                              [l
+                                                                                                                w
+                                                                                                                [m
+                                                                                                                  w
+                                                                                                                  x]]]
+                                                                                                            (con integer 1)] (error)
+                                                                                                          (con unit ())))
+                                                                                                      (case [(builtin lessThanInteger)
+                                                                                                          [(lam ad
+                                                                                                              [(lam ae
+                                                                                                                  (case [b
+                                                                                                                      ae] (error)
+                                                                                                                    [(lam af
+                                                                                                                        (case (case [b
+                                                                                                                              [(builtin unConstrData)
+                                                                                                                                [c
+                                                                                                                                  [f
+                                                                                                                                    ad]]]] (con bool False)
+                                                                                                                            (con bool True)) [(builtin subtractInteger)
+                                                                                                                            [(builtin unIData)
+                                                                                                                              [c
+                                                                                                                                af]]
+                                                                                                                            (con integer 1)]
+                                                                                                                          [(builtin unIData)
+                                                                                                                            [c
+                                                                                                                              af]]))
+                                                                                                                      [e
+                                                                                                                        ae]]
+                                                                                                                    (error)))
+                                                                                                                [(builtin unConstrData)
+                                                                                                                  [c
+                                                                                                                    ad]]])
+                                                                                                            [e
+                                                                                                              [(builtin unConstrData)
+                                                                                                                [c
+                                                                                                                  [f
+                                                                                                                    [e
+                                                                                                                      [(builtin unConstrData)
+                                                                                                                        [c
+                                                                                                                          [v
+                                                                                                                            w]]]]]]]]]
+                                                                                                          [(builtin unIData)
+                                                                                                            [c
+                                                                                                              [u
+                                                                                                                y]]]] (error)
+                                                                                                        (con unit ()))])
+                                                                                                  (case [i
+                                                                                                      w
+                                                                                                      [j
+                                                                                                        [e
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              [f
+                                                                                                                y]]]]]] (error)
+                                                                                                    (con unit ()))])
+                                                                                              (case [(builtin equalsByteString)
+                                                                                                  [(builtin sha2_256)
+                                                                                                    z]
+                                                                                                  [(builtin unBData)
+                                                                                                    [c
+                                                                                                      [p
+                                                                                                        y]]]] (error)
+                                                                                                (con unit ()))])))))
+                                                                                  (case (constr 0 [e
+                                                                                        [(builtin unConstrData)
+                                                                                          [c
+                                                                                            o]]]
+                                                                                      [e
+                                                                                        [(builtin unConstrData)
+                                                                                          [c
+                                                                                            r]]]
+                                                                                      s) (lam ag
+                                                                                      (lam ah
+                                                                                        (lam ai
+                                                                                          [(lam aj
+                                                                                              [(lam ak
+                                                                                                  (case [(builtin equalsInteger)
+                                                                                                      [(builtin unIData)
+                                                                                                        [l
+                                                                                                          ag
+                                                                                                          [m
+                                                                                                            ag
+                                                                                                            ah]]]
+                                                                                                      (con integer 1)] (error)
+                                                                                                    (con unit ())))
+                                                                                                (case [(builtin lessThanInteger)
+                                                                                                    [(builtin unIData)
+                                                                                                      [c
+                                                                                                        [u
+                                                                                                          ai]]]
+                                                                                                    [(lam al
+                                                                                                        [(lam am
+                                                                                                            (case [b
+                                                                                                                am] (error)
+                                                                                                              [(lam an
+                                                                                                                  (case (case [b
+                                                                                                                        [(builtin unConstrData)
+                                                                                                                          [c
+                                                                                                                            [f
+                                                                                                                              al]]]] (con bool False)
+                                                                                                                      (con bool True)) [(builtin addInteger)
+                                                                                                                      [(builtin unIData)
+                                                                                                                        [c
+                                                                                                                          an]]
+                                                                                                                      (con integer 1)]
+                                                                                                                    [(builtin unIData)
+                                                                                                                      [c
+                                                                                                                        an]]))
+                                                                                                                [e
+                                                                                                                  am]]
+                                                                                                              (error)))
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              al]]])
+                                                                                                      [e
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [c
+                                                                                                            [e
+                                                                                                              [(builtin unConstrData)
+                                                                                                                [c
+                                                                                                                  [v
+                                                                                                                    ag]]]]]]]]] (error)
+                                                                                                  (con unit ()))])
+                                                                                            (case [i
+                                                                                                ag
+                                                                                                [j
+                                                                                                  [e
+                                                                                                    [(builtin unConstrData)
+                                                                                                      [c
+                                                                                                        ai]]]]] (error)
+                                                                                              (con unit ()))]))))))
+                                                                              [a
+                                                                                (con integer 7)]])
+                                                                          [a
+                                                                            (con integer 3)]])
+                                                                      [(builtin unConstrData)
+                                                                        [c [f
+                                                                            o]]]])
+                                                                  [(lam ao
+                                                                      (case [b
+                                                                          ao] [e
+                                                                          [(builtin unConstrData)
+                                                                            [c
+                                                                              [e
+                                                                                ao]]]]
+                                                                        (error)))
+                                                                    [(builtin unConstrData)
+                                                                      [c [f
+                                                                          r]]]]])
+                                                              [e q]] (error)
+                                                            (error) (error)
+                                                            (error)))
+                                                        [(builtin unConstrData)
+                                                          [c [p o]]]]) [a
+                                                      (con integer 2)]]) [e
+                                                  [(builtin unConstrData) n]]]))
+                                          (lam ap
+                                            (lam aq
+                                              [(lam ar
+                                                  (case [b ar] [(lam as
+                                                        (case [b as] (error)
+                                                          [(builtin unBData) [c
+                                                              [e as]]]))
+                                                      [(builtin unConstrData) [c
+                                                          [e
+                                                            [(builtin unConstrData)
+                                                              [c [e
+                                                                  [(builtin unConstrData)
+                                                                    [c [f [e
+                                                                          [(builtin unConstrData)
+                                                                            [c
+                                                                              [e
+                                                                                ar]]]]]]]]]]]]]]
+                                                    (error)))
+                                                [(builtin unConstrData) [(lam at
+                                                      (lam au
+                                                        [h at [(lam av
+                                                              (lam aw
+                                                                [(builtin equalsData)
+                                                                  [c [e
+                                                                      [(builtin unConstrData)
+                                                                        aw]]]
+                                                                  av]))
+                                                            [(builtin constrData)
+                                                              (con integer 0)
+                                                              au]]]))
+                                                    [(builtin unListData) [c
+                                                        ap]] aq]]]))]) (lam ax
+                                        (lam ay
+                                          [(lam az
+                                              (lam ba
+                                                (case (constr 0 az
+                                                    (con data (I 0)) (lam bb
+                                                      [(lam bc
+                                                          (lam bd
+                                                            [(builtin iData)
+                                                              (case [ba bd] bc
+                                                                [(builtin addInteger)
+                                                                  bc
+                                                                  (con integer 1)])]))
+                                                        [(builtin unIData)
+                                                          bb]])) k)))
+                                            [(builtin unListData) [c ax]]
+                                            (lam be
+                                              [(lam bf
+                                                  (case [b bf] (con bool False)
+                                                    [(builtin equalsByteString)
+                                                      [(builtin unBData) [c [e
+                                                            bf]]] ay]))
+                                                [(builtin unConstrData) [c [e
+                                                      [(builtin unConstrData) [c
+                                                          [e
+                                                            [(builtin unConstrData)
+                                                              [c [f [e
+                                                                    [(builtin unConstrData)
+                                                                      be]]]]]]]]]]]])]))])
+                                  [g (lam k
+                                      (lam bg
+                                        (lam bh
+                                          (lam bi
+                                            (case bg (lam bj
+                                                (lam bk
+                                                  (case (constr 0 bk [bi bh bj]
+                                                      bi) k))) bh)))))]])
+                              (lam bl
+                                [(lam bm
+                                    (case [b bm] [(builtin unBData) [c [e bm]]]
+                                      (error))) [(builtin unConstrData) [c
+                                      bl]]])]) (lam bn
+                            (lam bo
+                              (case (constr 0 [(builtin unListData) [c [a
+                                        (con integer 8) bn]]] [(builtin bData)
+                                    bo] (lam bp
+                                    [(lam bq
+                                        (lam br
+                                          [(builtin equalsByteString) bq
+                                            [(builtin unBData) br]]))
+                                      [(builtin unBData) bp]])) (lam bs
+                                  (lam bt
+                                    (lam bu
+                                      (case (case [b [(builtin unConstrData) [h
+                                                bs (lam bv
+                                                  [(builtin equalsData) bv
+                                                    bt])]]] (con bool False)
+                                          (con bool True)) (con bool True)
+                                        (con bool False))))))))]) [g (lam h
+                          (lam bw
+                            (lam bx
+                              (case bw (lam by
+                                  (lam bz
+                                    (case [bx by] [h bz bx]
+                                      [(builtin constrData) (con integer 0) [d
+                                          by (con (list data) [])]])))
+                                (con data (Constr 1 []))))))]]) (lam ca
+                    [(lam cb [ca (lam cc [cb cb cc])]) (lam cb
+                        [ca (lam cc [cb cb cc])])])]))))))))


### PR DESCRIPTION
## Summary
Closes [IntersectMBO/UPLC-CAPE#180](https://github.com/IntersectMBO/UPLC-CAPE/issues/180) on the submissions side.

Each of the four Scalus-compiled scenarios (`factorial_naive_recursion`, `fibonacci_naive_recursion`, `fibonacci_prepacked`, `htlc`) now writes a second artifact `<scenario>-vanrossem.uplc` next to the current changPV build, compiled with `Options.release.copy(targetProtocolVersion = MajorProtocolVersion.vanRossemPV)` (case-on-builtins, batch6, dropList — projected late-June-2026 hard fork). Each preview is sanity-evaluated on a `PlutusVM.makePlutusV3VM(MajorProtocolVersion.vanRossemPV)` with the same input as the existing changPV harness.

For HTLC, which previously had no eval harness, this PR adds an off-chain `HtlcHarness` that constructs a minimal `ScriptContext` for both `Claim` and `Refund` redeemers (timeout-safe `Interval`, single script-credential input, signing party present) and measures CPU/MEM under both target PVs.

## Observed budget deltas (vanRossem vs changPV)

| Scenario | CPU | MEM | UPLC text size |
| --- | --- | --- | --- |
| factorial_naive_recursion | 8.76M → 6.87M (−22%) | 34662 → 28051 (−19%) | 382 → 310 B (−19%) |
| fibonacci_naive_recursion | 106.81M → 76.00M (−29%) | 413618 → 314521 (−24%) | 623 → 438 B (−30%) |
| fibonacci_prepacked | 1.745M → 1.573M (−10%) | 3009 → 2408 (−20%) | 527 → 463 B (−12%) |
| htlc claim | 28.09M → 21.42M (−24%) | 78821 → 60216 (−24%) | 35964 → 28008 B (−22%, both redeemers) |
| htlc refund | 26.66M → 19.98M (−25%) | 75023 → 57083 (−24%) | — |

## Test plan
- [x] `build-scalus` emits both artifacts for all four scenarios on a clean checkout (10 sources compile, 6 @main runs succeed).
- [x] `Util.assertEvaluatesTo` passes against `changPV` and `vanRossemPV` for `factorial_naive_recursion`, `fibonacci_naive_recursion`, `fibonacci_prepacked`.
- [x] `HtlcHarness.checkBoth` succeeds for both `Claim` and `Refund` on both target PVs.
- [x] CI green.

## Notes for the UPLC-CAPE consumer side
- New artifacts on `main` after merge:
  - `src/factorial_naive_recursion/factorial-vanrossem.uplc`
  - `src/fibonacci_naive_recursion/fibonacci-vanrossem.uplc`
  - `src/fibonacci_prepacked/fibonacci-vanrossem.uplc`
  - `src/htlc/htlc-vanrossem.uplc`
- @main targets unchanged: `factorial_naive_recursion.compileFactorialNaiveRecursion`, `fibonacci_naive_recursion.compileFibonacciNaiveRecursion`, `fibonacci_prepacked.compileFibonacciPrepacked`, `htlc.compileHtlc` — each writes both artifacts in a single run.
- Scalus version: 0.17.0 (same as `Scalus_0.17.0_Unisay`); commit hash will be reported after this PR merges.