### PR TITLE
chore: bump Scalus to 0.18.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "scalus-cape-submissions"
 version := "0.1.0"
 scalaVersion := "3.3.7"
 
-val scalusVersion = "0.17.0"
+val scalusVersion = "0.18.2"
 
 // Scalus dependencies
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Updates the Scalus toolchain from 0.17.0 to 0.18.2 (across 0.18.0, 0.18.1, 0.18.2).

Only `build.sbt` changes: `scalusVersion` moves to 0.18.2. Scala stays on 3.3.7 and the compiler-plugin coordinate (`scalus-plugin_3.3.7`) is unchanged; both are published for 0.18.2 on Maven Central. The Nix flake pins the JVM/sbt/Scala toolchain rather than Scalus, so it needs no change.

0.18.1 refreshed the Plutus V3 cost model, so measured execution budgets shift slightly, but the compiled output is unaffected here: every committed `.uplc` regenerates byte-for-byte and all scenarios still evaluate to their expected results.

Verified with `build-scalus`: all eight scenarios compile and their sanity evaluations pass on 0.18.2.
