### PR TITLE
feat: add two-party-escrow submission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This repository contains UPLC-CAPE benchmark submissions implemented using Scalus, a Scala-to-Plutus compiler. The project compiles Scala code to UPLC (Untyped Plutus Core) for Cardano blockchain execution.
 
 **Key Technologies:**
-- Scalus 0.17.0 - Scala-to-Plutus compiler (library + compiler plugin)
+- Scalus 0.18.2 - Scala-to-Plutus compiler (library + compiler plugin)
 - Scala 3.3.7
 - sbt 1.10.1
 - Plutus Core 1.1.0 target
@@ -48,6 +48,7 @@ sbt "runMain fibonacci_prepacked.compileFibonacciPrepacked"
 sbt "runMain factorial_naive_recursion.compileFactorialNaiveRecursion"
 sbt "runMain factorial.compileFactorial"
 sbt "runMain htlc.compileHtlc"
+sbt "runMain two_party_escrow.compileTwoPartyEscrow"
 ```
 
 **Important:** Main classes require the full package path (e.g., `fibonacci_naive_recursion.compileFibonacciNaiveRecursion`, not just `compileFibonacciNaiveRecursion`).
@@ -98,6 +99,13 @@ All scenarios are located in `src/`:
 
 **HTLC (Hashed Time-Locked Contract):**
 - `htlc/` - Spending validator (`Data -> Unit`) with `Claim(preimage)` / `Refund` redeemer. Uses the production-safe validity-range convention (claim checks upper bound of `txInfoValidRange`; refund checks lower bound).
+
+**Two-Party Escrow:**
+- `two_party_escrow/` - Spending validator (`Data -> Unit`) with a `Deposited -> Accepted | Refunded` state machine. Raw-integer redeemer (0=Deposit, 1=Accept, 2=Refund); buyer/seller keys, 75 ADA price and 1800s deadline baked in. Deposit records the (finite) upper bound of `txInfoValidRange` as `depositTime`; refund requires the lower bound strictly after `depositTime + 1800`.
+
+### Verification and measurement
+
+Correctness (all `measurements` accept, all `checks` reject) and metrics (CPU/memory/script size) are measured by the UPLC-CAPE framework, not locally: it evaluates the compiled `.uplc` against `scenarios/<scenario>/cape-tests.json` with the canonical evaluator. Do not build a local measurer.
 
 ### UPLC Compilation Process
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,8 @@
               sbt "runMain fibonacci_prepacked.compileFibonacciPrepacked" && \
               sbt "runMain factorial_naive_recursion.compileFactorialNaiveRecursion" && \
               sbt "runMain factorial.compileFactorial" && \
-              sbt "runMain htlc.compileHtlc"
+              sbt "runMain htlc.compileHtlc" && \
+              sbt "runMain two_party_escrow.compileTwoPartyEscrow"
             '')
           ];
 

--- a/src/two_party_escrow/README.md
+++ b/src/two_party_escrow/README.md
@@ -1,0 +1,39 @@
+# Two-Party Escrow (Scalus)
+
+Plutus V3 spending validator (`Data -> Unit`) for the UPLC-CAPE `two_party_escrow` scenario,
+compiled from Scala with Scalus.
+
+## Protocol
+
+A buyer deposits 75 ADA into the script; the seller may accept (funds released to the seller) or
+the buyer may refund after a deadline. State machine: `Deposited -> Accepted | Refunded`.
+
+- **Redeemer**: a raw integer — `0` = Deposit, `1` = Accept, `2` = Refund. Anything else (other
+  integers, constructors, bytestrings, lists, maps) is rejected.
+- **Datum**: `Constr 0 [state, depositTime]` where `state = Constr {0|1|2} []` =
+  Deposited | Accepted | Refunded.
+- **Baked-in parameters**: buyer key (`0xAA`×32), seller key (`0xBB`×32), price 75 ADA, deadline
+  1800 s, and the script credential (the ASCII bytes of the 58-character CAPE script hash).
+
+## Validation rules
+
+- **Deposit (0)**: signed by the buyer; exactly one output to the script address carrying exactly
+  75 ADA and datum `Deposited` whose `depositTime` equals the *upper* bound of the validity range
+  (which must be finite — an infinite upper bound is rejected).
+- **Accept (1)**: current datum state is `Deposited`; signed by the seller; the seller receives
+  exactly 75 ADA (summed across seller outputs); no funds remain at the script address.
+- **Refund (2)**: current datum state is `Deposited`; signed by the buyer; the validity range is
+  entirely after `depositTime + 1800` (finite lower bound, strictly greater); the buyer receives
+  exactly 75 ADA.
+
+## Implementation notes
+
+Adapted from the Scalus `scalus.examples.cape.twopartyescrow` reference, corrected for the CAPE
+evaluator's exact semantics: the deposit path has no own script input (the funding input is not the
+script's own input), so the script credential is baked in and the deposit output is located by
+credential; and `depositTime` is taken from the validity range's upper bound per the spec.
+
+Two artifacts are produced: `two_party_escrow.uplc` (changPV, mainnet) and
+`two_party_escrow-preview.uplc` (vanRossem preview). Both pass the full CAPE suite (all
+`measurements` succeed, all `checks` error) and beat the Plinth production baseline on CPU, memory
+and script size.

--- a/src/two_party_escrow/TwoPartyEscrow.scala
+++ b/src/two_party_escrow/TwoPartyEscrow.scala
@@ -1,0 +1,218 @@
+package two_party_escrow
+
+import common.Util
+import scalus.*
+import scalus.cardano.ledger.MajorProtocolVersion
+import scalus.compiler.{compile, Compile, Options}
+import scalus.cardano.onchain.plutus.prelude.*
+import scalus.cardano.onchain.plutus.prelude.Option.*
+import scalus.cardano.onchain.plutus.v1.IntervalBoundType
+import scalus.cardano.onchain.plutus.v2
+import scalus.cardano.onchain.plutus.v2.OutputDatum
+import scalus.cardano.onchain.plutus.v3.*
+import scalus.uplc.builtin.ByteString.*
+import scalus.uplc.builtin.Data
+import scalus.uplc.builtin.Data.{toData, FromData, ToData}
+
+/** UPLC-CAPE Two-Party Escrow Scenario
+  *
+  * Compiles to a `Data -> Unit` spending validator implementing a buyer/seller escrow with a
+  * `Deposited -> Accepted | Refunded` state machine. All parameters are baked in (buyer/seller
+  * keys, 75 ADA price, 1800s deadline) per the CAPE spec.
+  *
+  * Redeemer is a raw integer: 0 = Deposit, 1 = Accept, 2 = Refund.
+  *
+  * Datum is `Constr 0 [state, depositTime]` with `state = Constr {0|1|2} []` =
+  * Deposited | Accepted | Refunded.
+  *
+  * Adapted from the Scalus `scalus.examples.cape.twopartyescrow` reference, corrected for the
+  * faithful CAPE evaluator semantics:
+  *   - Deposit has no own script input (the funding input is `is_own_input:false`), so the script
+  *     credential is baked in rather than derived from `findOwnInput`.
+  *   - Deposit records `depositTime` as the *upper* bound of the validity range (finite; an
+  *     infinite upper bound is rejected), per the production-safe convention in the spec.
+  *   - The CAPE evaluator encodes the script hash as the ASCII bytes of "1"*58 (0x31 x 58), not a
+  *     hex-decoded 28-byte hash.
+  */
+
+// state: Constr(0, []) = Deposited, Constr(1, []) = Accepted, Constr(2, []) = Refunded
+enum EscrowState derives FromData, ToData:
+    case Deposited
+    case Accepted
+    case Refunded
+
+case class EscrowDatum(state: EscrowState, depositTime: BigInt) derives FromData, ToData
+
+@Compile
+object TwoPartyEscrowValidator {
+
+    // CAPE parameters baked in as top-level inline defs so they are properly inlined
+    // into the @Compile object.
+    private inline def buyerKeyHash: PubKeyHash =
+        PubKeyHash(hex"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    private inline def sellerKeyHash: PubKeyHash =
+        PubKeyHash(hex"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    // The CAPE evaluator builds the script address from the ASCII bytes of the 58-character
+    // "1111..." string (fromString), i.e. 0x31 repeated 58 times.
+    private inline def ownScriptCredential: Credential =
+        Credential.ScriptCredential(
+          hex"31313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131"
+        )
+    private inline def escrowPrice: Lovelace = BigInt(75_000_000)
+    private inline def deadlineSeconds: BigInt = BigInt(1800)
+
+    inline def validate(scData: Data): Unit = {
+        val sc = scData.to[ScriptContext]
+        sc.scriptInfo match
+            case ScriptInfo.SpendingScript(txOutRef, datum) =>
+                spend(datum, sc.redeemer, sc.txInfo, txOutRef)
+            case _ => fail("Only spending scripts are supported by this validator")
+    }
+
+    inline def spend(
+        datum: Option[Data],
+        redeemer: Data,
+        txInfo: TxInfo,
+        txOutRef: TxOutRef
+    ): Unit = {
+        val action = redeemer.to[BigInt]
+        if action == BigInt(0) then handleDeposit(txInfo)
+        else if action == BigInt(1) then handleAccept(datum, txInfo, txOutRef)
+        else if action == BigInt(2) then handleRefund(datum, txInfo, txOutRef)
+        else fail("Invalid redeemer")
+    }
+
+    inline def handleDeposit(txInfo: TxInfo): Unit = {
+        requireSignedBy(txInfo.signatories, buyerKeyHash, "Buyer must sign deposit")
+
+        // depositTime is recorded as the (finite) upper bound of the validity range.
+        val depositTime = upperBoundTime(txInfo.validRange)
+
+        val expectedDatum = EscrowDatum(
+          state = EscrowState.Deposited,
+          depositTime = depositTime
+        ).toData
+
+        val expectedOutput = TxOut(
+          address = Address(ownScriptCredential, Option.None),
+          value = Value.lovelace(escrowPrice),
+          datum = OutputDatum.OutputDatum(expectedDatum),
+          referenceScript = Option.None
+        )
+
+        val output = findOutputsByCredential(txInfo.outputs, ownScriptCredential) match
+            case List.Cons(head, List.Nil) => head
+            case _                         => fail("Expected exactly one script output")
+        require(output.toData == expectedOutput.toData, "Output must match expected deposit output")
+    }
+
+    inline def handleAccept(
+        datum: Option[Data],
+        txInfo: TxInfo,
+        txOutRef: TxOutRef
+    ): Unit = {
+        val escrowDatum = datum.getOrFail("Datum not found").to[EscrowDatum]
+        escrowDatum.state match
+            case EscrowState.Deposited => ()
+            case _                     => fail("Escrow must be in Deposited state")
+
+        requireSignedBy(txInfo.signatories, sellerKeyHash, "Seller must sign accept")
+
+        // The own input pins the escrow (must exist) and yields the script credential.
+        val ownCredential = findOwnInputOrFail(txInfo.inputs, txOutRef).resolved.address.credential
+
+        // Verify seller receives exactly the escrow price (summed across all seller outputs).
+        val outputs = txInfo.outputs
+        val sellerCred = Credential.PubKeyCredential(sellerKeyHash).toData
+        val sellerAda = outputs.foldLeft(BigInt(0)): (sum, out) =>
+            if out.address.credential.toData == sellerCred
+            then sum + out.value.lovelaceAmount
+            else sum
+        require(sellerAda == escrowPrice, "Seller must receive exactly escrow price")
+
+        // No funds should remain in the script (complete withdrawal).
+        require(
+          findOutputsByCredential(outputs, ownCredential).isEmpty,
+          "No funds should remain in script"
+        )
+    }
+
+    inline def handleRefund(
+        datum: Option[Data],
+        txInfo: TxInfo,
+        txOutRef: TxOutRef
+    ): Unit = {
+        val escrowDatum = datum.getOrFail("Datum not found").to[EscrowDatum]
+        escrowDatum.state match
+            case EscrowState.Deposited => ()
+            case _                     => fail("Escrow must be in Deposited state")
+
+        requireSignedBy(txInfo.signatories, buyerKeyHash, "Buyer must sign refund")
+
+        // Valid range must be entirely after the deadline (finite lower bound, strictly greater).
+        val deadline = escrowDatum.depositTime + deadlineSeconds
+        require(txInfo.validRange.isEntirelyAfter(deadline), "Deadline has not passed")
+
+        val ownCredential = findOwnInputOrFail(txInfo.inputs, txOutRef).resolved.address.credential
+
+        // Verify buyer receives exactly the escrow price (summed across all buyer outputs).
+        val outputs = txInfo.outputs
+        val buyerCred = Credential.PubKeyCredential(buyerKeyHash).toData
+        val buyerAda = outputs.foldLeft(BigInt(0)): (sum, out) =>
+            if out.address.credential.toData == buyerCred
+            then sum + out.value.lovelaceAmount
+            else sum
+        require(buyerAda == escrowPrice, "Buyer must receive exactly escrow price")
+
+        require(
+          findOutputsByCredential(outputs, ownCredential).isEmpty,
+          "No funds should remain in script"
+        )
+    }
+
+    // Largest POSIX time consistent with the interval's upper bound. Rejects an infinite bound.
+    def upperBoundTime(interval: Interval): BigInt =
+        interval.to.boundType match
+            case IntervalBoundType.Finite(t) =>
+                if interval.to.isInclusive then t else t - BigInt(1)
+            case _ => fail("Deposit requires a finite upper bound")
+
+    def findOwnInputOrFail(inputs: List[TxInInfo], txOutRef: TxOutRef): TxInInfo = {
+        def go(inputs: List[TxInInfo]): TxInInfo = inputs match
+            case List.Cons(head, tail) =>
+                if head.outRef.toData == txOutRef.toData then head
+                else go(tail)
+            case List.Nil => fail("Own input not found")
+        go(inputs)
+    }
+
+    def findOutputsByCredential(outputs: List[TxOut], cred: Credential): List[v2.TxOut] =
+        outputs.filter(_.address.credential.toData == cred.toData)
+
+    def requireSignedBy(
+        signatories: List[PubKeyHash],
+        party: PubKeyHash,
+        message: String
+    ): Unit = {
+        def go(signatories: List[PubKeyHash]): Unit = signatories match
+            case List.Nil              => fail(message)
+            case List.Cons(head, tail) => if head.toData == party.toData then () else go(tail)
+        go(signatories)
+    }
+}
+
+@main def compileTwoPartyEscrow(): Unit =
+    val sir = compile(TwoPartyEscrowValidator.validate)
+
+    val program = common.Renamer.rename(sir.toUplcOptimized(using Options.release)().plutusV3)
+    Util.writeUplc("two_party_escrow", "two_party_escrow.uplc", program.pretty.render(80))
+
+    // vanRossem preview build (case-on-builtins, batch6, dropList)
+    val vanRossem = Options.release.copy(targetProtocolVersion = MajorProtocolVersion.vanRossemPV)
+    val programVR = common.Renamer.rename(sir.toUplcOptimized(using vanRossem)().plutusV3)
+    Util.writeUplc(
+      "two_party_escrow",
+      "two_party_escrow-preview.uplc",
+      programVR.pretty.render(80)
+    )
+    // Verification + metrics are measured by UPLC-CAPE via poreus://UPLC-CAPE/measure-artifact.

--- a/src/two_party_escrow/TwoPartyEscrow.scala
+++ b/src/two_party_escrow/TwoPartyEscrow.scala
@@ -7,7 +7,6 @@ import scalus.compiler.{compile, Compile, Options}
 import scalus.cardano.onchain.plutus.prelude.*
 import scalus.cardano.onchain.plutus.prelude.Option.*
 import scalus.cardano.onchain.plutus.v1.IntervalBoundType
-import scalus.cardano.onchain.plutus.v2
 import scalus.cardano.onchain.plutus.v2.OutputDatum
 import scalus.cardano.onchain.plutus.v3.*
 import scalus.uplc.builtin.ByteString.*
@@ -186,7 +185,7 @@ object TwoPartyEscrowValidator {
         go(inputs)
     }
 
-    def findOutputsByCredential(outputs: List[TxOut], cred: Credential): List[v2.TxOut] =
+    def findOutputsByCredential(outputs: List[TxOut], cred: Credential): List[TxOut] =
         outputs.filter(_.address.credential.toData == cred.toData)
 
     def requireSignedBy(

--- a/src/two_party_escrow/two_party_escrow.uplc
+++ b/src/two_party_escrow/two_party_escrow.uplc
@@ -1,0 +1,509 @@
+(program 1.1.0 (case (constr 0 (force (force (builtin chooseList)))
+      (force (force (builtin fstPair))) (force (builtin headList))
+      (force (builtin ifThenElse)) (force (builtin mkCons))
+      (force (force (builtin sndPair))) (force (builtin tailList))) (lam a
+      (lam b
+        (lam c
+          (lam d
+            (lam e
+              (lam f
+                (lam g
+                  [(lam h
+                      [(lam i
+                          [(lam j
+                              [(lam k
+                                  [(lam l
+                                      [(lam m
+                                          [(lam n
+                                              [(lam o
+                                                  (lam p
+                                                    [(lam q
+                                                        [(lam r
+                                                            [(lam s
+                                                                (force (case (constr 0 [(builtin equalsInteger)
+                                                                      [b s]
+                                                                      (con integer 1)]
+                                                                    (delay [(lam t
+                                                                        (force (case (constr 0 [(builtin equalsInteger)
+                                                                              [(builtin unIData)
+                                                                                t]
+                                                                              (con integer 0)]
+                                                                            (delay [(lam u
+                                                                                (force (case (constr 0 [(builtin equalsData)
+                                                                                      [(builtin constrData)
+                                                                                        (con integer 0)
+                                                                                        [(lam v
+                                                                                            (force (case (constr 0 v
+                                                                                                (delay (error))
+                                                                                                (delay (force (case (constr 0 [g
+                                                                                                      v]
+                                                                                                    (delay [f
+                                                                                                      [(builtin unConstrData)
+                                                                                                        [c
+                                                                                                          v]]])
+                                                                                                    (delay (error))) a)))) a)))
+                                                                                          [(builtin unListData)
+                                                                                            [k
+                                                                                              [(builtin unListData)
+                                                                                                [c
+                                                                                                  [g
+                                                                                                    [g
+                                                                                                      [f
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [c
+                                                                                                            q]]]]]]]
+                                                                                              (con data (Constr 1 [B #31313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131]))]]]]
+                                                                                      [(builtin constrData)
+                                                                                        (con integer 0)
+                                                                                        [e
+                                                                                          (con data (Constr 0 [Constr 1 [B #31313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131], Constr 1 []]))
+                                                                                          [e
+                                                                                            (con data (Map [(B #, Map [(B #, I 75000000)])]))
+                                                                                            [e
+                                                                                              [(builtin constrData)
+                                                                                                (con integer 2)
+                                                                                                [e
+                                                                                                  [(builtin constrData)
+                                                                                                    (con integer 0)
+                                                                                                    [e
+                                                                                                      (con data (Constr 0 []))
+                                                                                                      [e
+                                                                                                        [(builtin iData)
+                                                                                                          [(lam w
+                                                                                                              [(lam x
+                                                                                                                  (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                        [b
+                                                                                                                          x]
+                                                                                                                        (con integer 1)]
+                                                                                                                      (delay [(lam y
+                                                                                                                          (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                    [b
+                                                                                                                                      [(builtin unConstrData)
+                                                                                                                                        [c
+                                                                                                                                          [g
+                                                                                                                                            w]]]]
+                                                                                                                                    (con integer 0)]
+                                                                                                                                  (con bool False)
+                                                                                                                                  (con bool True)) d)
+                                                                                                                              (delay [(builtin unIData)
+                                                                                                                                [c
+                                                                                                                                  y]])
+                                                                                                                              (delay [(builtin subtractInteger)
+                                                                                                                                [(builtin unIData)
+                                                                                                                                  [c
+                                                                                                                                    y]]
+                                                                                                                                (con integer 1)])) d)))
+                                                                                                                        [f
+                                                                                                                          x]])
+                                                                                                                      (delay (error))) d)))
+                                                                                                                [(builtin unConstrData)
+                                                                                                                  [c
+                                                                                                                    w]]])
+                                                                                                            [f
+                                                                                                              [(builtin unConstrData)
+                                                                                                                [c
+                                                                                                                  [g
+                                                                                                                    [f
+                                                                                                                      [(builtin unConstrData)
+                                                                                                                        [c
+                                                                                                                          [g
+                                                                                                                            [g
+                                                                                                                              [g
+                                                                                                                                [g
+                                                                                                                                  [g
+                                                                                                                                    [g
+                                                                                                                                      [g
+                                                                                                                                        [f
+                                                                                                                                          [(builtin unConstrData)
+                                                                                                                                            [c
+                                                                                                                                              q]]]]]]]]]]]]]]]]]]]
+                                                                                                        (con (list data) [])]]]
+                                                                                                  (con (list data) [])]]
+                                                                                              (con (list data) [Constr 1 []])]]]]]
+                                                                                    (delay (con unit ()))
+                                                                                    (delay (error))) d)))
+                                                                              (case (constr 0 [(builtin unListData)
+                                                                                    [c
+                                                                                      [g
+                                                                                        [g
+                                                                                          [g
+                                                                                            [g
+                                                                                              [g
+                                                                                                [g
+                                                                                                  [g
+                                                                                                    [g
+                                                                                                      [f
+                                                                                                        [(builtin unConstrData)
+                                                                                                          [c
+                                                                                                            q]]]]]]]]]]]]]
+                                                                                  (con bytestring #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+                                                                                  (con string "Buyer must sign deposit")) i)])
+                                                                            (delay [(lam z
+                                                                                [(lam aa
+                                                                                    [(lam ab
+                                                                                        [(lam ac
+                                                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                  [(builtin unIData)
+                                                                                                    t]
+                                                                                                  (con integer 1)]
+                                                                                                (delay [(lam ad
+                                                                                                    [(lam ae
+                                                                                                        [(lam af
+                                                                                                            [(lam ag
+                                                                                                                [(lam ah
+                                                                                                                    (force (case (constr 0 [o
+                                                                                                                          [(builtin unListData)
+                                                                                                                            [k
+                                                                                                                              ag
+                                                                                                                              af]]]
+                                                                                                                        (delay (con unit ()))
+                                                                                                                        (delay (error))) d)))
+                                                                                                                  (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                        [(builtin unIData)
+                                                                                                                          (case (constr 0 ag
+                                                                                                                              (con data (I 0))
+                                                                                                                              (lam ai
+                                                                                                                                [(lam aj
+                                                                                                                                    (lam ak
+                                                                                                                                      [(builtin iData)
+                                                                                                                                        [(lam al
+                                                                                                                                            (force (case (constr 0 [(builtin equalsData)
+                                                                                                                                                  [c
+                                                                                                                                                    [f
+                                                                                                                                                      [(builtin unConstrData)
+                                                                                                                                                        [c
+                                                                                                                                                          al]]]]
+                                                                                                                                                  (con data (Constr 0 [B #bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]))]
+                                                                                                                                                (delay [(builtin addInteger)
+                                                                                                                                                  aj
+                                                                                                                                                  [(builtin unIData)
+                                                                                                                                                    [n
+                                                                                                                                                      [c
+                                                                                                                                                        [g
+                                                                                                                                                          al]]]]])
+                                                                                                                                                (delay aj)) d)))
+                                                                                                                                          [f
+                                                                                                                                            [(builtin unConstrData)
+                                                                                                                                              ak]]]]))
+                                                                                                                                  [(builtin unIData)
+                                                                                                                                    ai]])) m)]
+                                                                                                                        (con integer 75000000)]
+                                                                                                                      (delay (con unit ()))
+                                                                                                                      (delay (error))) d))])
+                                                                                                              [(builtin unListData)
+                                                                                                                [c
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [f
+                                                                                                                        [(builtin unConstrData)
+                                                                                                                          [c
+                                                                                                                            q]]]]]]]])
+                                                                                                          [c
+                                                                                                            [f
+                                                                                                              [(builtin unConstrData)
+                                                                                                                [c
+                                                                                                                  [f
+                                                                                                                    [(builtin unConstrData)
+                                                                                                                      [c
+                                                                                                                        [g
+                                                                                                                          [l
+                                                                                                                            [(builtin unListData)
+                                                                                                                              [c
+                                                                                                                                [f
+                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                    [c
+                                                                                                                                      q]]]]]
+                                                                                                                            aa]]]]]]]]]])
+                                                                                                      (case (constr 0 [(builtin unListData)
+                                                                                                            [c
+                                                                                                              [g
+                                                                                                                [g
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [g
+                                                                                                                        [g
+                                                                                                                          [g
+                                                                                                                            [g
+                                                                                                                              [f
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  [c
+                                                                                                                                    q]]]]]]]]]]]]]
+                                                                                                          (con bytestring #bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+                                                                                                          (con string "Seller must sign accept")) i)])
+                                                                                                  (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                        [b
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              [f
+                                                                                                                [(builtin unConstrData)
+                                                                                                                  (force [ac
+                                                                                                                    (delay (error))])]]]]]
+                                                                                                        (con integer 0)]
+                                                                                                      (delay (con unit ()))
+                                                                                                      (delay (error))) d))])
+                                                                                                (delay (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                      [(builtin unIData)
+                                                                                                        t]
+                                                                                                      (con integer 2)]
+                                                                                                    (delay [(lam am
+                                                                                                        [(lam an
+                                                                                                            [(lam ao
+                                                                                                                [(lam ap
+                                                                                                                    [(lam aq
+                                                                                                                        [(lam ar
+                                                                                                                            [(lam as
+                                                                                                                                (force (case (constr 0 [o
+                                                                                                                                      [(builtin unListData)
+                                                                                                                                        [k
+                                                                                                                                          ar
+                                                                                                                                          aq]]]
+                                                                                                                                    (delay (con unit ()))
+                                                                                                                                    (delay (error))) d)))
+                                                                                                                              (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                    [(builtin unIData)
+                                                                                                                                      (case (constr 0 ar
+                                                                                                                                          (con data (I 0))
+                                                                                                                                          (lam at
+                                                                                                                                            [(lam au
+                                                                                                                                                (lam av
+                                                                                                                                                  [(builtin iData)
+                                                                                                                                                    [(lam aw
+                                                                                                                                                        (force (case (constr 0 [(builtin equalsData)
+                                                                                                                                                              [c
+                                                                                                                                                                [f
+                                                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                                                    [c
+                                                                                                                                                                      aw]]]]
+                                                                                                                                                              (con data (Constr 0 [B #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]))]
+                                                                                                                                                            (delay [(builtin addInteger)
+                                                                                                                                                              au
+                                                                                                                                                              [(builtin unIData)
+                                                                                                                                                                [n
+                                                                                                                                                                  [c
+                                                                                                                                                                    [g
+                                                                                                                                                                      aw]]]]])
+                                                                                                                                                            (delay au)) d)))
+                                                                                                                                                      [f
+                                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                                          av]]]]))
+                                                                                                                                              [(builtin unIData)
+                                                                                                                                                at]])) m)]
+                                                                                                                                    (con integer 75000000)]
+                                                                                                                                  (delay (con unit ()))
+                                                                                                                                  (delay (error))) d))])
+                                                                                                                          [(builtin unListData)
+                                                                                                                            [c
+                                                                                                                              [g
+                                                                                                                                [g
+                                                                                                                                  [f
+                                                                                                                                    [(builtin unConstrData)
+                                                                                                                                      [c
+                                                                                                                                        q]]]]]]]])
+                                                                                                                      [c
+                                                                                                                        [f
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [c
+                                                                                                                              [f
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  [c
+                                                                                                                                    [g
+                                                                                                                                      [l
+                                                                                                                                        [(builtin unListData)
+                                                                                                                                          [c
+                                                                                                                                            [f
+                                                                                                                                              [(builtin unConstrData)
+                                                                                                                                                [c
+                                                                                                                                                  q]]]]]
+                                                                                                                                        aa]]]]]]]]]])
+                                                                                                                  (force (case (constr 0 [(lam ax
+                                                                                                                          (lam ay
+                                                                                                                            [(lam az
+                                                                                                                                [(lam ba
+                                                                                                                                    (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                          [b
+                                                                                                                                            ba]
+                                                                                                                                          (con integer 1)]
+                                                                                                                                        (delay [(lam bb
+                                                                                                                                            (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                                      [b
+                                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                                          [c
+                                                                                                                                                            [g
+                                                                                                                                                              az]]]]
+                                                                                                                                                      (con integer 0)]
+                                                                                                                                                    (con bool False)
+                                                                                                                                                    (con bool True)) d)
+                                                                                                                                                (delay [(builtin lessThanInteger)
+                                                                                                                                                  ay
+                                                                                                                                                  [(builtin unIData)
+                                                                                                                                                    [c
+                                                                                                                                                      bb]]])
+                                                                                                                                                (delay [(builtin lessThanEqualsInteger)
+                                                                                                                                                  ay
+                                                                                                                                                  [(builtin unIData)
+                                                                                                                                                    [c
+                                                                                                                                                      bb]]])) d)))
+                                                                                                                                          [f
+                                                                                                                                            ba]])
+                                                                                                                                        (delay (con bool False))) d)))
+                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                    [c
+                                                                                                                                      az]]])
+                                                                                                                              [f
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  [c
+                                                                                                                                    ax]]]]))
+                                                                                                                        [f
+                                                                                                                          [(builtin unConstrData)
+                                                                                                                            [c
+                                                                                                                              [g
+                                                                                                                                [g
+                                                                                                                                  [g
+                                                                                                                                    [g
+                                                                                                                                      [g
+                                                                                                                                        [g
+                                                                                                                                          [g
+                                                                                                                                            [f
+                                                                                                                                              [(builtin unConstrData)
+                                                                                                                                                [c
+                                                                                                                                                  q]]]]]]]]]]]]]
+                                                                                                                        [(builtin addInteger)
+                                                                                                                          [(builtin unIData)
+                                                                                                                            [c
+                                                                                                                              [g
+                                                                                                                                am]]]
+                                                                                                                          (con integer 1800)]]
+                                                                                                                      (delay (con unit ()))
+                                                                                                                      (delay (error))) d))])
+                                                                                                              (case (constr 0 [(builtin unListData)
+                                                                                                                    [c
+                                                                                                                      [g
+                                                                                                                        [g
+                                                                                                                          [g
+                                                                                                                            [g
+                                                                                                                              [g
+                                                                                                                                [g
+                                                                                                                                  [g
+                                                                                                                                    [g
+                                                                                                                                      [f
+                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                          [c
+                                                                                                                                            q]]]]]]]]]]]]]
+                                                                                                                  (con bytestring #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+                                                                                                                  (con string "Buyer must sign refund")) i)])
+                                                                                                          (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                [b
+                                                                                                                  [(builtin unConstrData)
+                                                                                                                    [c
+                                                                                                                      am]]]
+                                                                                                                (con integer 0)]
+                                                                                                              (delay (con unit ()))
+                                                                                                              (delay (error))) d))])
+                                                                                                      [f
+                                                                                                        [(builtin unConstrData)
+                                                                                                          (force [ac
+                                                                                                            (delay (error))])]]])
+                                                                                                    (delay (error))) d)))) d)))
+                                                                                          [d
+                                                                                            [(builtin equalsInteger)
+                                                                                              [b
+                                                                                                ab]
+                                                                                              (con integer 0)]
+                                                                                            (delay [c
+                                                                                              [f
+                                                                                                ab]])]])
+                                                                                      [(builtin unConstrData)
+                                                                                        [c
+                                                                                          [g
+                                                                                            z]]]])
+                                                                                  [f
+                                                                                    [(builtin unConstrData)
+                                                                                      [c
+                                                                                        z]]]])
+                                                                              [f
+                                                                                s]])) d)))
+                                                                      [c r]])
+                                                                    (delay (error))) d)))
+                                                              [(builtin unConstrData)
+                                                                [c [g r]]]]) [g
+                                                            q]]) [f
+                                                        [(builtin unConstrData)
+                                                          p]]])) (lam bc
+                                                  (force (case (constr 0 bc
+                                                      (delay (con bool True))
+                                                      (delay (con bool False))) a)))])
+                                            (lam bd
+                                              [(lam be
+                                                  [(lam bf
+                                                      [c [g [e [b bf] [e [f bf]
+                                                              (con (list data) [])]]]])
+                                                    [c [(builtin unMapData) [c
+                                                          [g [e [b be] [e [f be]
+                                                                (con (list data) [])]]]]]]])
+                                                [c [(builtin unMapData) bd]]])])
+                                        [h (lam m
+                                            (lam bg
+                                              (lam bh
+                                                (lam bi
+                                                  (force (case (constr 0 bg
+                                                      (delay bh)
+                                                      (delay (case (constr 0 [g
+                                                            bg] [bi bh [c bg]]
+                                                          bi) m))) a))))))]])
+                                    (lam bj
+                                      (lam bk
+                                        [h (lam bl
+                                            [(lam bm
+                                                (lam bn
+                                                  (force (case (constr 0 bn
+                                                      (delay (error)) (delay [f
+                                                        [(builtin unConstrData)
+                                                          (force (case (constr 0 [(builtin equalsData)
+                                                                [c [f
+                                                                    [(builtin unConstrData)
+                                                                      [c bn]]]]
+                                                                bm] (delay [c
+                                                                bn])
+                                                              (delay [(builtin constrData)
+                                                                (con integer 0)
+                                                                [bl [g
+                                                                    bn]]])) d))]])) a))))
+                                              [(builtin constrData)
+                                                (con integer 0) bk]]) bj]))])
+                                (lam bo
+                                  (lam bp
+                                    (case (constr 0 bo (con data (List []))
+                                        (lam bq
+                                          (lam br
+                                            [(builtin listData) [(lam bs
+                                                  (force (case (constr 0 [(builtin equalsData)
+                                                        [c [f
+                                                            [(builtin unConstrData)
+                                                              [c [f
+                                                                  [(builtin unConstrData)
+                                                                    bq]]]]]] bp]
+                                                      (delay [e bq bs])
+                                                      (delay bs)) d)))
+                                                [(builtin unListData)
+                                                  br]]]))) j)))]) [h (lam j
+                                (lam bt
+                                  (lam bu
+                                    (lam bv
+                                      (force (case (constr 0 bt (delay bu)
+                                          (delay [bv [c bt] (case (constr 0 [g
+                                                  bt] bu bv) j)])) a))))))]])
+                        (lam bw
+                          (lam bx
+                            [(lam by
+                                (lam bz
+                                  [h (lam ca
+                                      (lam cb
+                                        (force (case (constr 0 cb
+                                            (delay (error))
+                                            (delay (force (case (constr 0 [(builtin equalsData)
+                                                  [c cb] by]
+                                                (delay (con unit ())) (delay [ca
+                                                  [g cb]])) d)))) a)))) bw]))
+                              [(builtin bData) bx]]))]) (lam cc
+                      [(lam cd [cc (lam ce [cd cd ce])]) (lam cd
+                          [cc (lam ce [cd cd ce])])])])))))))))


### PR DESCRIPTION
Adds the Scalus implementation of the UPLC-CAPE `two_party_escrow` scenario. This PR carries the mainnet (changPV) build; the preview (van Rossem) build follows in a separate PR.

It is a `Data -> Unit` spending validator with a Deposited -> Accepted | Refunded state machine. The redeemer is a raw integer (0 = Deposit, 1 = Accept, 2 = Refund); the buyer/seller keys, the 75 ADA price and the 1800s deadline are baked in. Deposit records the finite upper bound of the validity range as `depositTime`; refund requires the lower bound to be strictly after `depositTime + 1800`.

Adapted from the Scalus `scalus.examples.cape.twopartyescrow` example, corrected for the CAPE evaluator's exact semantics: the deposit path has no own script input, so the script credential is baked in and the deposit output is located by credential rather than via `findOwnInput`.

Measured against the scenario's `cape-tests.json` with the UPLC-CAPE evaluator, all 47 evaluations match their expected outcomes. The mainnet build measures cpu_sum 297,557,371, mem_sum 775,801 and script_size_bytes 1,638.

Also wires the scenario into `build-scalus` and documents it in CLAUDE.md.
