### PR TITLE
feat: add linear-vesting submission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ sbt "runMain factorial_naive_recursion.compileFactorialNaiveRecursion"
 sbt "runMain factorial.compileFactorial"
 sbt "runMain htlc.compileHtlc"
 sbt "runMain two_party_escrow.compileTwoPartyEscrow"
+sbt "runMain linear_vesting.compileLinearVesting"
 ```
 
 **Important:** Main classes require the full package path (e.g., `fibonacci_naive_recursion.compileFibonacciNaiveRecursion`, not just `compileFibonacciNaiveRecursion`).
@@ -102,6 +103,9 @@ All scenarios are located in `src/`:
 
 **Two-Party Escrow:**
 - `two_party_escrow/` - Spending validator (`Data -> Unit`) with a `Deposited -> Accepted | Refunded` state machine. Raw-integer redeemer (0=Deposit, 1=Accept, 2=Refund); buyer/seller keys, 75 ADA price and 1800s deadline baked in. Deposit records the (finite) upper bound of `txInfoValidRange` as `depositTime`; refund requires the lower bound strictly after `depositTime + 1800`.
+
+**Linear Vesting:**
+- `linear_vesting/` - Spending validator (`Data -> Unit`) releasing a native asset on an installment schedule. Nullary-constructor redeemer (`Constr 0 []`=PartialUnlock, `Constr 1 []`=FullUnlock); all parameters in the 7-field datum. Partial unlock enforces the `divCeil` schedule, datum preservation and a single-script-input anti-double-satisfaction guard, taking the first (most-recently-added) script output as the continuing UTxO.
 
 ### Verification and measurement
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,8 @@
               sbt "runMain factorial_naive_recursion.compileFactorialNaiveRecursion" && \
               sbt "runMain factorial.compileFactorial" && \
               sbt "runMain htlc.compileHtlc" && \
-              sbt "runMain two_party_escrow.compileTwoPartyEscrow"
+              sbt "runMain two_party_escrow.compileTwoPartyEscrow" && \
+              sbt "runMain linear_vesting.compileLinearVesting"
             '')
           ];
 

--- a/src/linear_vesting/LinearVesting.scala
+++ b/src/linear_vesting/LinearVesting.scala
@@ -1,0 +1,140 @@
+package linear_vesting
+
+import common.Util
+import scalus.*
+import scalus.cardano.ledger.MajorProtocolVersion
+import scalus.compiler.{compile, Compile, Options}
+import scalus.cardano.onchain.plutus.prelude.*
+import scalus.cardano.onchain.plutus.prelude.Option.*
+import scalus.cardano.onchain.plutus.v2.OutputDatum
+import scalus.cardano.onchain.plutus.v3.*
+import scalus.uplc.builtin.{ByteString, Data}
+import scalus.uplc.builtin.Data.{toData, FromData, ToData}
+
+/** UPLC-CAPE Linear Vesting Scenario
+  *
+  * Compiles to a `Data -> Unit` spending validator releasing a native asset to a beneficiary on an
+  * installment schedule. All parameters live in the datum (nothing baked in).
+  *
+  * Redeemer is a nullary constructor: `Constr 0 []` = PartialUnlock, `Constr 1 []` = FullUnlock
+  * (a raw integer redeemer is rejected because it fails to decode as the enum).
+  *
+  * Datum is `Constr 0 [beneficiary, vestingAsset, totalVestingQty, vestingPeriodStart,
+  * vestingPeriodEnd, firstUnlockPossibleAfter, totalInstallments]`.
+  */
+
+case class VestingAsset(currencySymbol: ByteString, tokenName: ByteString) derives FromData, ToData
+
+case class VestingDatum(
+    beneficiary: Address,
+    vestingAsset: VestingAsset,
+    totalVestingQty: BigInt,
+    vestingPeriodStart: BigInt,
+    vestingPeriodEnd: BigInt,
+    firstUnlockPossibleAfter: BigInt,
+    totalInstallments: BigInt
+) derives FromData,
+      ToData
+
+enum VestingRedeemer derives FromData, ToData:
+    case PartialUnlock
+    case FullUnlock
+
+@Compile
+object LinearVestingValidator {
+
+    inline def validate(scData: Data): Unit = {
+        val sc = scData.to[ScriptContext]
+        sc.scriptInfo match
+            case ScriptInfo.SpendingScript(txOutRef, datumOpt) =>
+                val datumData = datumOpt.getOrFail("Datum not found")
+                val datum = datumData.to[VestingDatum]
+                sc.redeemer.to[VestingRedeemer] match
+                    case VestingRedeemer.PartialUnlock =>
+                        handlePartial(datum, datumData, sc.txInfo, txOutRef)
+                    case VestingRedeemer.FullUnlock =>
+                        handleFull(datum, sc.txInfo)
+            case _ => fail("Only spending scripts are supported by this validator")
+    }
+
+    inline def handleFull(datum: VestingDatum, txInfo: TxInfo): Unit = {
+        require(txInfo.isSignedBy(beneficiaryPkh(datum)), "Beneficiary must sign")
+        // Lower bound finite and strictly after the vesting period end.
+        require(
+          txInfo.validRange.isEntirelyAfter(datum.vestingPeriodEnd),
+          "Vesting period has not ended"
+        )
+    }
+
+    inline def handlePartial(
+        datum: VestingDatum,
+        datumData: Data,
+        txInfo: TxInfo,
+        txOutRef: TxOutRef
+    ): Unit = {
+        require(txInfo.isSignedBy(beneficiaryPkh(datum)), "Beneficiary must sign")
+        // Lower bound finite and strictly after the first-unlock time (also rejects an infinite
+        // lower bound, so `getValidityStartTime` below sees a finite value).
+        require(
+          txInfo.validRange.isEntirelyAfter(datum.firstUnlockPossibleAfter),
+          "First unlock time not reached"
+        )
+        val currentTime = txInfo.getValidityStartTime
+
+        val ownInput = txInfo.findOwnInputOrFail(txOutRef)
+        val ownCredential = ownInput.resolved.address.credential
+
+        // Exactly one input from this script address (anti double-satisfaction).
+        require(
+          txInfo.findOwnInputsByCredential(ownCredential).length == BigInt(1),
+          "Exactly one script input allowed"
+        )
+
+        // The continuing output is the first (most-recently-added) script output.
+        val continuing = txInfo.findOwnOutputsByCredential(ownCredential).head
+
+        val cs = datum.vestingAsset.currencySymbol
+        val tn = datum.vestingAsset.tokenName
+        val oldRemaining = ownInput.resolved.value.quantityOf(cs, tn)
+        val newRemaining = continuing.value.quantityOf(cs, tn)
+
+        require(newRemaining > BigInt(0), "Remaining quantity must be positive (use FullUnlock)")
+        require(newRemaining < oldRemaining, "Remaining quantity must strictly decrease")
+        require(
+          newRemaining == expectedRemaining(datum, currentTime),
+          "Remaining quantity must match the vesting schedule"
+        )
+
+        // Datum must be preserved unchanged on the continuing output.
+        continuing.datum match
+            case OutputDatum.OutputDatum(d) => require(d == datumData, "Datum must be preserved")
+            case _                          => fail("Continuing output must carry an inline datum")
+    }
+
+    def expectedRemaining(datum: VestingDatum, currentTime: BigInt): BigInt = {
+        val vestingPeriodLength = datum.vestingPeriodEnd - datum.vestingPeriodStart
+        val timeBetweenTwoInstallments = divCeil(vestingPeriodLength, datum.totalInstallments)
+        val vestingTimeRemaining = datum.vestingPeriodEnd - currentTime
+        val futureInstallments = divCeil(vestingTimeRemaining, timeBetweenTwoInstallments)
+        divCeil(futureInstallments * datum.totalVestingQty, datum.totalInstallments)
+    }
+
+    def divCeil(x: BigInt, y: BigInt): BigInt = BigInt(1) + (x - BigInt(1)) / y
+
+    def beneficiaryPkh(datum: VestingDatum): PubKeyHash =
+        datum.beneficiary.credential match
+            case Credential.PubKeyCredential(pkh) => pkh
+            case _                                => fail("Beneficiary must be a public key credential")
+}
+
+@main def compileLinearVesting(): Unit =
+    val sir = compile(LinearVestingValidator.validate)
+
+    val program = common.Renamer.rename(sir.toUplcOptimized(using Options.release)().plutusV3)
+    Util.writeUplc("linear_vesting", "linear_vesting.uplc", program.pretty.render(80))
+
+    // vanRossem preview build (case-on-builtins, batch6, dropList)
+    val vanRossem = Options.release.copy(targetProtocolVersion = MajorProtocolVersion.vanRossemPV)
+    val programVR = common.Renamer.rename(sir.toUplcOptimized(using vanRossem)().plutusV3)
+    Util.writeUplc("linear_vesting", "linear_vesting-preview.uplc", programVR.pretty.render(80))
+    // Verification + metrics are measured by UPLC-CAPE via poreus://UPLC-CAPE/measure-artifact.

--- a/src/linear_vesting/LinearVesting.scala
+++ b/src/linear_vesting/LinearVesting.scala
@@ -91,7 +91,9 @@ object LinearVestingValidator {
         )
 
         // The continuing output is the first (most-recently-added) script output.
-        val continuing = txInfo.findOwnOutputsByCredential(ownCredential).head
+        val continuing = txInfo.findOwnOutputsByCredential(ownCredential) match
+            case List.Cons(head, _) => head
+            case List.Nil           => fail("Missing continuing script output")
 
         val cs = datum.vestingAsset.currencySymbol
         val tn = datum.vestingAsset.tokenName

--- a/src/linear_vesting/README.md
+++ b/src/linear_vesting/README.md
@@ -1,0 +1,45 @@
+# Linear Vesting (Scalus)
+
+Plutus V3 spending validator (`Data -> Unit`) for the UPLC-CAPE `linear_vesting` scenario, compiled
+from Scala with Scalus.
+
+## Protocol
+
+A native asset is locked at the script and released to a beneficiary on a linear installment
+schedule. The beneficiary either partially unlocks (leaving the remaining amount at the script) or
+fully unlocks after the vesting period ends.
+
+- **Redeemer**: a nullary constructor — `Constr 0 []` = PartialUnlock, `Constr 1 []` = FullUnlock.
+  A raw integer redeemer is rejected (it fails to decode as the enum).
+- **Datum**: `Constr 0 [beneficiary, vestingAsset, totalVestingQty, vestingPeriodStart,
+  vestingPeriodEnd, firstUnlockPossibleAfter, totalInstallments]`. All parameters live in the datum
+  (nothing is baked in).
+
+## Validation rules
+
+- **FullUnlock**: signed by the beneficiary; the validity range is entirely after
+  `vestingPeriodEnd` (finite lower bound, strictly greater).
+- **PartialUnlock**: signed by the beneficiary; validity range entirely after
+  `firstUnlockPossibleAfter`; exactly one input from the script address (anti double-satisfaction);
+  the continuing (first / most-recently-added) script output preserves the datum unchanged and holds
+  a remaining quantity that is positive, strictly less than the input's, and equal to the schedule:
+
+  ```
+  divCeil(x, y)          = 1 + (x - 1) / y
+  timeBetween            = divCeil(vestingPeriodEnd - vestingPeriodStart, totalInstallments)
+  futureInstallments     = divCeil(vestingPeriodEnd - currentTime, timeBetween)
+  expectedRemainingQty   = divCeil(futureInstallments * totalVestingQty, totalInstallments)
+  ```
+
+  where `currentTime` is the validity range's lower bound.
+
+## Implementation notes
+
+The continuing output is selected as the *first* script output (the CAPE evaluator prepends
+outputs, so the head is the most-recently-added one); the schedule tests attach a second, stale
+script output that must be ignored.
+
+Two artifacts are produced: `linear_vesting.uplc` (changPV, mainnet) and
+`linear_vesting-preview.uplc` (vanRossem preview). Both pass the full CAPE suite (all
+`measurements` succeed, all `checks` error) and beat the Plinth production baseline on CPU, memory
+and script size.

--- a/src/linear_vesting/linear_vesting.uplc
+++ b/src/linear_vesting/linear_vesting.uplc
@@ -1,0 +1,627 @@
+(program 1.1.0 (case (constr 0 (force (force (builtin chooseList)))
+      (force (force (builtin fstPair))) (force (builtin headList))
+      (force (builtin ifThenElse)) (force (builtin mkCons))
+      (force (force (builtin sndPair))) (force (builtin tailList))) (lam a
+      (lam b
+        (lam c
+          (lam d
+            (lam e
+              (lam f
+                (lam g
+                  [(lam h
+                      [(lam i
+                          [(lam j
+                              [(lam k
+                                  [(lam l
+                                      [(lam m
+                                          [(lam n
+                                              [(lam o
+                                                  [(lam p
+                                                      [(lam q
+                                                          [(lam r
+                                                              [(lam s
+                                                                  (lam t
+                                                                    [(lam u
+                                                                        [(lam v
+                                                                            [(lam w
+                                                                                (force (case (constr 0 [(builtin equalsInteger)
+                                                                                      [b
+                                                                                        w]
+                                                                                      (con integer 1)]
+                                                                                    (delay [(lam x
+                                                                                        [(lam y
+                                                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                  [b
+                                                                                                    [(builtin unConstrData)
+                                                                                                      [c
+                                                                                                        v]]]
+                                                                                                  (con integer 0)]
+                                                                                                (delay [(lam z
+                                                                                                    [(lam aa
+                                                                                                        [(lam ab
+                                                                                                            [(lam ac
+                                                                                                                [(lam ad
+                                                                                                                    [(lam ae
+                                                                                                                        [(lam af
+                                                                                                                            [(lam ag
+                                                                                                                                [(lam ah
+                                                                                                                                    [(lam ai
+                                                                                                                                        [(lam aj
+                                                                                                                                            [(lam ak
+                                                                                                                                                [(lam al
+                                                                                                                                                    [(lam am
+                                                                                                                                                        [(lam an
+                                                                                                                                                            [(lam ao
+                                                                                                                                                                [(lam ap
+                                                                                                                                                                    [(lam aq
+                                                                                                                                                                        [(lam ar
+                                                                                                                                                                            (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                                                                  [b
+                                                                                                                                                                                    ar]
+                                                                                                                                                                                  (con integer 2)]
+                                                                                                                                                                                (delay (force (case (constr 0 [(builtin equalsData)
+                                                                                                                                                                                      [c
+                                                                                                                                                                                        [f
+                                                                                                                                                                                          ar]]
+                                                                                                                                                                                      y]
+                                                                                                                                                                                    (delay (con unit ()))
+                                                                                                                                                                                    (delay (error))) d)))
+                                                                                                                                                                                (delay (error))) d)))
+                                                                                                                                                                          [(builtin unConstrData)
+                                                                                                                                                                            [c
+                                                                                                                                                                              [g
+                                                                                                                                                                                am]]]])
+                                                                                                                                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                                                            an
+                                                                                                                                                                            [(lam as
+                                                                                                                                                                                (lam at
+                                                                                                                                                                                  [(lam au
+                                                                                                                                                                                      [(lam av
+                                                                                                                                                                                          [(lam aw
+                                                                                                                                                                                              [(lam ax
+                                                                                                                                                                                                  [(lam ay
+                                                                                                                                                                                                      [s
+                                                                                                                                                                                                        [(builtin multiplyInteger)
+                                                                                                                                                                                                          [s
+                                                                                                                                                                                                            [ay
+                                                                                                                                                                                                              at]
+                                                                                                                                                                                                            [s
+                                                                                                                                                                                                              [ay
+                                                                                                                                                                                                                [(builtin unIData)
+                                                                                                                                                                                                                  [c
+                                                                                                                                                                                                                    av]]]
+                                                                                                                                                                                                              ax]]
+                                                                                                                                                                                                          [(builtin unIData)
+                                                                                                                                                                                                            [c
+                                                                                                                                                                                                              au]]]
+                                                                                                                                                                                                        ax])
+                                                                                                                                                                                                    [(builtin subtractInteger)
+                                                                                                                                                                                                      [(builtin unIData)
+                                                                                                                                                                                                        [c
+                                                                                                                                                                                                          aw]]]])
+                                                                                                                                                                                                [(builtin unIData)
+                                                                                                                                                                                                  [c
+                                                                                                                                                                                                    [g
+                                                                                                                                                                                                      [g
+                                                                                                                                                                                                        aw]]]]])
+                                                                                                                                                                                            [g
+                                                                                                                                                                                              av]])
+                                                                                                                                                                                        [g
+                                                                                                                                                                                          au]])
+                                                                                                                                                                                    [g
+                                                                                                                                                                                      [g
+                                                                                                                                                                                        as]]]))
+                                                                                                                                                                              [f
+                                                                                                                                                                                [(builtin unConstrData)
+                                                                                                                                                                                  y]]
+                                                                                                                                                                              ab]]
+                                                                                                                                                                          (delay (con unit ()))
+                                                                                                                                                                          (delay (error))) d))])
+                                                                                                                                                                  (force (case (constr 0 [(builtin lessThanInteger)
+                                                                                                                                                                        an
+                                                                                                                                                                        al]
+                                                                                                                                                                      (delay (con unit ()))
+                                                                                                                                                                      (delay (error))) d))])
+                                                                                                                                                              (force (case (constr 0 [(builtin lessThanInteger)
+                                                                                                                                                                    (con integer 0)
+                                                                                                                                                                    an]
+                                                                                                                                                                  (delay (con unit ()))
+                                                                                                                                                                  (delay (error))) d))])
+                                                                                                                                                          (case (constr 0 [c
+                                                                                                                                                                am]
+                                                                                                                                                              aj
+                                                                                                                                                              ak) r)])
+                                                                                                                                                      [g
+                                                                                                                                                        [f
+                                                                                                                                                          [(builtin unConstrData)
+                                                                                                                                                            af]]]])
+                                                                                                                                                  (case (constr 0 [c
+                                                                                                                                                        [g
+                                                                                                                                                          ac]]
+                                                                                                                                                      aj
+                                                                                                                                                      ak) r)])
+                                                                                                                                              [(builtin unBData)
+                                                                                                                                                ai]])
+                                                                                                                                          [(builtin unBData)
+                                                                                                                                            ah]])
+                                                                                                                                      [c
+                                                                                                                                        [g
+                                                                                                                                          ag]]])
+                                                                                                                                  [c
+                                                                                                                                    ag]])
+                                                                                                                              [f
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  [c
+                                                                                                                                    [g
+                                                                                                                                      [f
+                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                          y]]]]]]])
+                                                                                                                          [(lam az
+                                                                                                                              (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                    [b
+                                                                                                                                      az]
+                                                                                                                                    (con integer 0)]
+                                                                                                                                  (delay [c
+                                                                                                                                    [f
+                                                                                                                                      az]])
+                                                                                                                                  (delay (error))) d)))
+                                                                                                                            [(builtin unConstrData)
+                                                                                                                              [(lam ba
+                                                                                                                                  (force (case (constr 0 ba
+                                                                                                                                      (delay (con data (Constr 1 [])))
+                                                                                                                                      (delay [(builtin constrData)
+                                                                                                                                        (con integer 0)
+                                                                                                                                        [e
+                                                                                                                                          [c
+                                                                                                                                            ba]
+                                                                                                                                          (con (list data) [])]])) a)))
+                                                                                                                                [(builtin unListData)
+                                                                                                                                  [(lam bb
+                                                                                                                                      (lam bc
+                                                                                                                                        [o
+                                                                                                                                          [(builtin unListData)
+                                                                                                                                            [c
+                                                                                                                                              [g
+                                                                                                                                                [g
+                                                                                                                                                  bb]]]]
+                                                                                                                                          (lam bd
+                                                                                                                                            [(builtin equalsData)
+                                                                                                                                              [c
+                                                                                                                                                [f
+                                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                                    [c
+                                                                                                                                                      [f
+                                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                                          bd]]]]]]
+                                                                                                                                              bc])]))
+                                                                                                                                    [f
+                                                                                                                                      [(builtin unConstrData)
+                                                                                                                                        [c
+                                                                                                                                          u]]]
+                                                                                                                                    ad]]]]]])
+                                                                                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                            [(builtin unIData)
+                                                                                                                              (case (constr 0 [(builtin unListData)
+                                                                                                                                    [(lam be
+                                                                                                                                        (lam bf
+                                                                                                                                          [o
+                                                                                                                                            [(builtin unListData)
+                                                                                                                                              [c
+                                                                                                                                                be]]
+                                                                                                                                            (lam bg
+                                                                                                                                              [(builtin equalsData)
+                                                                                                                                                [c
+                                                                                                                                                  [f
+                                                                                                                                                    [(builtin unConstrData)
+                                                                                                                                                      [c
+                                                                                                                                                        [f
+                                                                                                                                                          [(builtin unConstrData)
+                                                                                                                                                            [c
+                                                                                                                                                              [g
+                                                                                                                                                                [f
+                                                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                                                    bg]]]]]]]]]]
+                                                                                                                                                bf])]))
+                                                                                                                                      [f
+                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                          [c
+                                                                                                                                            u]]]
+                                                                                                                                      ad]]
+                                                                                                                                  (con data (I 0))
+                                                                                                                                  (lam bh
+                                                                                                                                    [(lam bi
+                                                                                                                                        (lam bj
+                                                                                                                                          [(builtin iData)
+                                                                                                                                            [(builtin addInteger)
+                                                                                                                                              bi
+                                                                                                                                              (con integer 1)]]))
+                                                                                                                                      [(builtin unIData)
+                                                                                                                                        bh]])) m)]
+                                                                                                                            (con integer 1)]
+                                                                                                                          (delay (con unit ()))
+                                                                                                                          (delay (error))) d))])
+                                                                                                                  [c
+                                                                                                                    [f
+                                                                                                                      [(builtin unConstrData)
+                                                                                                                        [c
+                                                                                                                          ac]]]]])
+                                                                                                              [f
+                                                                                                                [(builtin unConstrData)
+                                                                                                                  [c
+                                                                                                                    [g
+                                                                                                                      [f
+                                                                                                                        [(builtin unConstrData)
+                                                                                                                          [(lam bk
+                                                                                                                              (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                                    [b
+                                                                                                                                      bk]
+                                                                                                                                    (con integer 0)]
+                                                                                                                                  (delay [c
+                                                                                                                                    [f
+                                                                                                                                      bk]])
+                                                                                                                                  (delay (error))) d)))
+                                                                                                                            [(builtin unConstrData)
+                                                                                                                              [(lam bl
+                                                                                                                                  (lam bm
+                                                                                                                                    [(lam bn
+                                                                                                                                        (lam bo
+                                                                                                                                          [i
+                                                                                                                                            bn
+                                                                                                                                            [(lam bp
+                                                                                                                                                (lam bq
+                                                                                                                                                  [(builtin equalsData)
+                                                                                                                                                    [c
+                                                                                                                                                      [f
+                                                                                                                                                        [(builtin unConstrData)
+                                                                                                                                                          bq]]]
+                                                                                                                                                    bp]))
+                                                                                                                                              [(builtin constrData)
+                                                                                                                                                (con integer 0)
+                                                                                                                                                bo]]]))
+                                                                                                                                      [(builtin unListData)
+                                                                                                                                        [c
+                                                                                                                                          bl]]
+                                                                                                                                      bm]))
+                                                                                                                                [f
+                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                    [c
+                                                                                                                                      u]]]
+                                                                                                                                [f
+                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                    [c
+                                                                                                                                      x]]]]]]]]]]]]])
+                                                                                                          [(lam br
+                                                                                                              (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                                    [b
+                                                                                                                      br]
+                                                                                                                    (con integer 1)]
+                                                                                                                  (delay [(builtin unIData)
+                                                                                                                    [c
+                                                                                                                      [f
+                                                                                                                        br]]])
+                                                                                                                  (delay (con integer 0))) d)))
+                                                                                                            [(builtin unConstrData)
+                                                                                                              [c
+                                                                                                                [f
+                                                                                                                  [(builtin unConstrData)
+                                                                                                                    [c
+                                                                                                                      [f
+                                                                                                                        [(builtin unConstrData)
+                                                                                                                          [c
+                                                                                                                            [g
+                                                                                                                              [g
+                                                                                                                                [g
+                                                                                                                                  [g
+                                                                                                                                    [g
+                                                                                                                                      [g
+                                                                                                                                        [g
+                                                                                                                                          [f
+                                                                                                                                            [(builtin unConstrData)
+                                                                                                                                              [c
+                                                                                                                                                u]]]]]]]]]]]]]]]]]]]])
+                                                                                                      (force (case (constr 0 [l
+                                                                                                            [f
+                                                                                                              [(builtin unConstrData)
+                                                                                                                [c
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [g
+                                                                                                                        [g
+                                                                                                                          [g
+                                                                                                                            [g
+                                                                                                                              [g
+                                                                                                                                [f
+                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                    [c
+                                                                                                                                      u]]]]]]]]]]]]]
+                                                                                                            [(builtin unIData)
+                                                                                                              [c
+                                                                                                                [g
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [g
+                                                                                                                        [g
+                                                                                                                          [f
+                                                                                                                            [(builtin unConstrData)
+                                                                                                                              y]]]]]]]]]]
+                                                                                                          (delay (con unit ()))
+                                                                                                          (delay (error))) d))])
+                                                                                                  (force (case (constr 0 [j
+                                                                                                        [f
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              u]]]
+                                                                                                        [k
+                                                                                                          [f
+                                                                                                            [(builtin unConstrData)
+                                                                                                              y]]]]
+                                                                                                      (delay (con unit ()))
+                                                                                                      (delay (error))) d))])
+                                                                                                (delay [(lam bs
+                                                                                                    (force (case (constr 0 [l
+                                                                                                          [f
+                                                                                                            [(builtin unConstrData)
+                                                                                                              [c
+                                                                                                                [g
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [g
+                                                                                                                        [g
+                                                                                                                          [g
+                                                                                                                            [g
+                                                                                                                              [f
+                                                                                                                                [(builtin unConstrData)
+                                                                                                                                  [c
+                                                                                                                                    u]]]]]]]]]]]]]
+                                                                                                          [(builtin unIData)
+                                                                                                            [c
+                                                                                                              [g
+                                                                                                                [g
+                                                                                                                  [g
+                                                                                                                    [g
+                                                                                                                      [f
+                                                                                                                        [(builtin unConstrData)
+                                                                                                                          y]]]]]]]]]
+                                                                                                        (delay (con unit ()))
+                                                                                                        (delay (error))) d)))
+                                                                                                  (force (case (constr 0 [j
+                                                                                                        [f
+                                                                                                          [(builtin unConstrData)
+                                                                                                            [c
+                                                                                                              u]]]
+                                                                                                        [k
+                                                                                                          [f
+                                                                                                            [(builtin unConstrData)
+                                                                                                              y]]]]
+                                                                                                      (delay (con unit ()))
+                                                                                                      (delay (error))) d))])) d)))
+                                                                                          [(lam bt
+                                                                                              (force (case (constr 0 [(builtin equalsInteger)
+                                                                                                    [b
+                                                                                                      bt]
+                                                                                                    (con integer 0)]
+                                                                                                  (delay [c
+                                                                                                    [f
+                                                                                                      bt]])
+                                                                                                  (delay (error))) d)))
+                                                                                            [(builtin unConstrData)
+                                                                                              [c
+                                                                                                [g
+                                                                                                  x]]]]])
+                                                                                      [f
+                                                                                        w]])
+                                                                                    (delay (error))) d)))
+                                                                              [(builtin unConstrData)
+                                                                                [c
+                                                                                  [g
+                                                                                    v]]]])
+                                                                          [g
+                                                                            u]])
+                                                                      [f
+                                                                        [(builtin unConstrData)
+                                                                          t]]]))
+                                                                (lam bu
+                                                                  (lam bv
+                                                                    [(builtin addInteger)
+                                                                      (con integer 1)
+                                                                      [(builtin divideInteger)
+                                                                        [(builtin subtractInteger)
+                                                                          bu
+                                                                          (con integer 1)]
+                                                                        bv]]))])
+                                                            (lam bw
+                                                              (lam bx
+                                                                [(lam by
+                                                                    (lam bz
+                                                                      [(lam ca
+                                                                          (force (case (constr 0 [(builtin equalsInteger)
+                                                                                [b
+                                                                                  ca]
+                                                                                (con integer 0)]
+                                                                              (delay [(builtin unIData)
+                                                                                [(lam cb
+                                                                                    (lam cc
+                                                                                      (force (case (constr 0 [(builtin equalsInteger)
+                                                                                            [b
+                                                                                              cb]
+                                                                                            (con integer 0)]
+                                                                                          (delay [c
+                                                                                            [f
+                                                                                              cb]])
+                                                                                          (delay cc)) d))))
+                                                                                  [(builtin unConstrData)
+                                                                                    (case (constr 0 [c
+                                                                                          [f
+                                                                                            ca]]
+                                                                                        [(builtin bData)
+                                                                                          bz]
+                                                                                        (lam cd
+                                                                                          [(lam ce
+                                                                                              (lam cf
+                                                                                                [q
+                                                                                                  ce
+                                                                                                  [(builtin unBData)
+                                                                                                    cf]]))
+                                                                                            [(builtin unBData)
+                                                                                              cd]])) p)]
+                                                                                  (con data (I 0))]])
+                                                                              (delay (con integer 0))) d)))
+                                                                        [(builtin unConstrData)
+                                                                          (case (constr 0 bw
+                                                                              by
+                                                                              (lam cg
+                                                                                [(lam ch
+                                                                                    (lam ci
+                                                                                      [q
+                                                                                        ch
+                                                                                        [(builtin unBData)
+                                                                                          ci]]))
+                                                                                  [(builtin unBData)
+                                                                                    cg]])) p)]]))
+                                                                  [(builtin bData)
+                                                                    bx]]))])
+                                                        (lam cj
+                                                          (lam ck
+                                                            (force (case (constr 0 [(builtin lessThanByteString)
+                                                                  cj ck]
+                                                                (delay (con data (Constr 0 [])))
+                                                                (delay (case (constr 0 [(builtin equalsByteString)
+                                                                      cj ck]
+                                                                    (con data (Constr 1 []))
+                                                                    (con data (Constr 2 []))) d))) d))))])
+                                                    (lam cl
+                                                      (lam cm
+                                                        (lam cn
+                                                          [h (lam co
+                                                              (lam cp
+                                                                (force (case (constr 0 cp
+                                                                    (delay (con data (Constr 1 [])))
+                                                                    (delay [(lam cq
+                                                                        [(lam cr
+                                                                            (force (case (constr 0 [cr
+                                                                                  (con integer 0)]
+                                                                                (delay (con data (Constr 1 [])))
+                                                                                (delay (force (case (constr 0 [cr
+                                                                                      (con integer 1)]
+                                                                                    (delay [(builtin constrData)
+                                                                                      (con integer 0)
+                                                                                      [e
+                                                                                        [f
+                                                                                          cq]
+                                                                                        (con (list data) [])]])
+                                                                                    (delay [co
+                                                                                      [g
+                                                                                        cp]])) d)))) d)))
+                                                                          [(builtin equalsInteger)
+                                                                            [b
+                                                                              [(builtin unConstrData)
+                                                                                [cn
+                                                                                  cm
+                                                                                  [b
+                                                                                    cq]]]]]])
+                                                                      [c
+                                                                        cp]])) a))))
+                                                            [(builtin unMapData)
+                                                              cl]])))]) (lam cs
+                                                  (lam ct
+                                                    (case (constr 0 cs
+                                                        (con data (List []))
+                                                        (lam cu
+                                                          (lam cv
+                                                            [(builtin listData)
+                                                              [(lam cw
+                                                                  (force (case (constr 0 [ct
+                                                                        cu]
+                                                                      (delay [e
+                                                                        cu cw])
+                                                                      (delay cw)) d)))
+                                                                [(builtin unListData)
+                                                                  cv]]]))) n)))])
+                                            [h (lam n
+                                                (lam cx
+                                                  (lam cy
+                                                    (lam cz
+                                                      (force (case (constr 0 cx
+                                                          (delay cy) (delay [cz
+                                                            [c cx]
+                                                            (case (constr 0 [g
+                                                                  cx] cy
+                                                                cz) n)])) a))))))]])
+                                        [h (lam m
+                                            (lam da
+                                              (lam db
+                                                (lam dc
+                                                  (force (case (constr 0 da
+                                                      (delay db)
+                                                      (delay (case (constr 0 [g
+                                                            da] [dc db [c da]]
+                                                          dc) m))) a))))))]])
+                                    (lam dd
+                                      (lam de
+                                        [(lam df
+                                            [(lam dg
+                                                (force (case (constr 0 [(builtin equalsInteger)
+                                                      [b dg] (con integer 1)]
+                                                    (delay [(lam dh
+                                                        (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                                  [b
+                                                                    [(builtin unConstrData)
+                                                                      [c [g
+                                                                          df]]]]
+                                                                  (con integer 0)]
+                                                                (con bool False)
+                                                                (con bool True)) d)
+                                                            (delay [(builtin lessThanInteger)
+                                                              de
+                                                              [(builtin unIData)
+                                                                [c dh]]])
+                                                            (delay [(builtin lessThanEqualsInteger)
+                                                              de
+                                                              [(builtin unIData)
+                                                                [c dh]]])) d)))
+                                                      [f dg]])
+                                                    (delay (con bool False))) d)))
+                                              [(builtin unConstrData) [c df]]])
+                                          [f [(builtin unConstrData) [c
+                                                dd]]]]))]) (lam di
+                                  [(lam dj
+                                      (force (case (constr 0 [(builtin equalsInteger)
+                                            [b dj] (con integer 0)]
+                                          (delay [(builtin unBData) [c [f dj]]])
+                                          (delay (error))) d)))
+                                    [(builtin unConstrData) [c [f
+                                          [(builtin unConstrData) [c di]]]]]])])
+                            (lam dk
+                              (lam dl
+                                (case (constr 0 [(builtin unListData) [c [g [g
+                                            [g [g [g [g [g [g dk]]]]]]]]]]
+                                    [(builtin bData) dl] (lam dm
+                                      [(lam dn
+                                          (lam do
+                                            [(builtin equalsByteString) dn
+                                              [(builtin unBData) do]]))
+                                        [(builtin unBData) dm]])) (lam dp
+                                    (lam dq
+                                      (lam dr
+                                        (case (constr 0 (case (constr 0 [(builtin equalsInteger)
+                                                  [b [(builtin unConstrData) [i
+                                                        dp (lam ds
+                                                          [(builtin equalsData)
+                                                            ds dq])]]]
+                                                  (con integer 0)]
+                                                (con bool False)
+                                                (con bool True)) d)
+                                            (con bool False)
+                                            (con bool True)) d)))))))]) [h
+                          (lam i
+                            (lam dt
+                              (lam du
+                                (force (case (constr 0 dt
+                                    (delay (con data (Constr 1 [])))
+                                    (delay (force (case (constr 0 [du [c dt]]
+                                        (delay [(builtin constrData)
+                                          (con integer 0) [e [c dt]
+                                            (con (list data) [])]]) (delay [i [g
+                                            dt] du])) d)))) a)))))]]) (lam dv
+                      [(lam dw [dv (lam dx [dw dw dx])]) (lam dw
+                          [dv (lam dx [dw dw dx])])])])))))))))

--- a/src/linear_vesting/linear_vesting.uplc
+++ b/src/linear_vesting/linear_vesting.uplc
@@ -132,9 +132,7 @@
                                                                                                                                                               aj
                                                                                                                                                               ak) r)])
                                                                                                                                                       [g
-                                                                                                                                                        [f
-                                                                                                                                                          [(builtin unConstrData)
-                                                                                                                                                            af]]]])
+                                                                                                                                                        af]])
                                                                                                                                                   (case (constr 0 [c
                                                                                                                                                         [g
                                                                                                                                                           ac]]
@@ -157,58 +155,46 @@
                                                                                                                                         [(builtin unConstrData)
                                                                                                                                           y]]]]]]])
                                                                                                                           [(lam az
-                                                                                                                              (force (case (constr 0 [(builtin equalsInteger)
-                                                                                                                                    [b
-                                                                                                                                      az]
-                                                                                                                                    (con integer 0)]
-                                                                                                                                  (delay [c
-                                                                                                                                    [f
-                                                                                                                                      az]])
-                                                                                                                                  (delay (error))) d)))
-                                                                                                                            [(builtin unConstrData)
+                                                                                                                              (force (case (constr 0 az
+                                                                                                                                  (delay (error))
+                                                                                                                                  (delay [f
+                                                                                                                                    [(builtin unConstrData)
+                                                                                                                                      [c
+                                                                                                                                        az]]])) a)))
+                                                                                                                            [(builtin unListData)
                                                                                                                               [(lam ba
-                                                                                                                                  (force (case (constr 0 ba
-                                                                                                                                      (delay (con data (Constr 1 [])))
-                                                                                                                                      (delay [(builtin constrData)
-                                                                                                                                        (con integer 0)
-                                                                                                                                        [e
-                                                                                                                                          [c
-                                                                                                                                            ba]
-                                                                                                                                          (con (list data) [])]])) a)))
-                                                                                                                                [(builtin unListData)
-                                                                                                                                  [(lam bb
-                                                                                                                                      (lam bc
-                                                                                                                                        [o
-                                                                                                                                          [(builtin unListData)
-                                                                                                                                            [c
-                                                                                                                                              [g
-                                                                                                                                                [g
-                                                                                                                                                  bb]]]]
-                                                                                                                                          (lam bd
-                                                                                                                                            [(builtin equalsData)
-                                                                                                                                              [c
-                                                                                                                                                [f
-                                                                                                                                                  [(builtin unConstrData)
-                                                                                                                                                    [c
-                                                                                                                                                      [f
-                                                                                                                                                        [(builtin unConstrData)
-                                                                                                                                                          bd]]]]]]
-                                                                                                                                              bc])]))
-                                                                                                                                    [f
-                                                                                                                                      [(builtin unConstrData)
+                                                                                                                                  (lam bb
+                                                                                                                                    [o
+                                                                                                                                      [(builtin unListData)
                                                                                                                                         [c
-                                                                                                                                          u]]]
-                                                                                                                                    ad]]]]]])
+                                                                                                                                          [g
+                                                                                                                                            [g
+                                                                                                                                              ba]]]]
+                                                                                                                                      (lam bc
+                                                                                                                                        [(builtin equalsData)
+                                                                                                                                          [c
+                                                                                                                                            [f
+                                                                                                                                              [(builtin unConstrData)
+                                                                                                                                                [c
+                                                                                                                                                  [f
+                                                                                                                                                    [(builtin unConstrData)
+                                                                                                                                                      bc]]]]]]
+                                                                                                                                          bb])]))
+                                                                                                                                [f
+                                                                                                                                  [(builtin unConstrData)
+                                                                                                                                    [c
+                                                                                                                                      u]]]
+                                                                                                                                ad]]]])
                                                                                                                       (force (case (constr 0 [(builtin equalsInteger)
                                                                                                                             [(builtin unIData)
                                                                                                                               (case (constr 0 [(builtin unListData)
-                                                                                                                                    [(lam be
-                                                                                                                                        (lam bf
+                                                                                                                                    [(lam bd
+                                                                                                                                        (lam be
                                                                                                                                           [o
                                                                                                                                             [(builtin unListData)
                                                                                                                                               [c
-                                                                                                                                                be]]
-                                                                                                                                            (lam bg
+                                                                                                                                                bd]]
+                                                                                                                                            (lam bf
                                                                                                                                               [(builtin equalsData)
                                                                                                                                                 [c
                                                                                                                                                   [f
@@ -220,23 +206,23 @@
                                                                                                                                                               [g
                                                                                                                                                                 [f
                                                                                                                                                                   [(builtin unConstrData)
-                                                                                                                                                                    bg]]]]]]]]]]
-                                                                                                                                                bf])]))
+                                                                                                                                                                    bf]]]]]]]]]]
+                                                                                                                                                be])]))
                                                                                                                                       [f
                                                                                                                                         [(builtin unConstrData)
                                                                                                                                           [c
                                                                                                                                             u]]]
                                                                                                                                       ad]]
                                                                                                                                   (con data (I 0))
-                                                                                                                                  (lam bh
-                                                                                                                                    [(lam bi
-                                                                                                                                        (lam bj
+                                                                                                                                  (lam bg
+                                                                                                                                    [(lam bh
+                                                                                                                                        (lam bi
                                                                                                                                           [(builtin iData)
                                                                                                                                             [(builtin addInteger)
-                                                                                                                                              bi
+                                                                                                                                              bh
                                                                                                                                               (con integer 1)]]))
                                                                                                                                       [(builtin unIData)
-                                                                                                                                        bh]])) m)]
+                                                                                                                                        bg]])) m)]
                                                                                                                             (con integer 1)]
                                                                                                                           (delay (con unit ()))
                                                                                                                           (delay (error))) d))])
@@ -251,37 +237,37 @@
                                                                                                                     [g
                                                                                                                       [f
                                                                                                                         [(builtin unConstrData)
-                                                                                                                          [(lam bk
+                                                                                                                          [(lam bj
                                                                                                                               (force (case (constr 0 [(builtin equalsInteger)
                                                                                                                                     [b
-                                                                                                                                      bk]
+                                                                                                                                      bj]
                                                                                                                                     (con integer 0)]
                                                                                                                                   (delay [c
                                                                                                                                     [f
-                                                                                                                                      bk]])
+                                                                                                                                      bj]])
                                                                                                                                   (delay (error))) d)))
                                                                                                                             [(builtin unConstrData)
-                                                                                                                              [(lam bl
-                                                                                                                                  (lam bm
-                                                                                                                                    [(lam bn
-                                                                                                                                        (lam bo
+                                                                                                                              [(lam bk
+                                                                                                                                  (lam bl
+                                                                                                                                    [(lam bm
+                                                                                                                                        (lam bn
                                                                                                                                           [i
-                                                                                                                                            bn
-                                                                                                                                            [(lam bp
-                                                                                                                                                (lam bq
+                                                                                                                                            bm
+                                                                                                                                            [(lam bo
+                                                                                                                                                (lam bp
                                                                                                                                                   [(builtin equalsData)
                                                                                                                                                     [c
                                                                                                                                                       [f
                                                                                                                                                         [(builtin unConstrData)
-                                                                                                                                                          bq]]]
-                                                                                                                                                    bp]))
+                                                                                                                                                          bp]]]
+                                                                                                                                                    bo]))
                                                                                                                                               [(builtin constrData)
                                                                                                                                                 (con integer 0)
-                                                                                                                                                bo]]]))
+                                                                                                                                                bn]]]))
                                                                                                                                       [(builtin unListData)
                                                                                                                                         [c
-                                                                                                                                          bl]]
-                                                                                                                                      bm]))
+                                                                                                                                          bk]]
+                                                                                                                                      bl]))
                                                                                                                                 [f
                                                                                                                                   [(builtin unConstrData)
                                                                                                                                     [c
@@ -290,15 +276,15 @@
                                                                                                                                   [(builtin unConstrData)
                                                                                                                                     [c
                                                                                                                                       x]]]]]]]]]]]]])
-                                                                                                          [(lam br
+                                                                                                          [(lam bq
                                                                                                               (force (case (constr 0 [(builtin equalsInteger)
                                                                                                                     [b
-                                                                                                                      br]
+                                                                                                                      bq]
                                                                                                                     (con integer 1)]
                                                                                                                   (delay [(builtin unIData)
                                                                                                                     [c
                                                                                                                       [f
-                                                                                                                        br]]])
+                                                                                                                        bq]]])
                                                                                                                   (delay (con integer 0))) d)))
                                                                                                             [(builtin unConstrData)
                                                                                                               [c
@@ -357,7 +343,7 @@
                                                                                                               y]]]]
                                                                                                       (delay (con unit ()))
                                                                                                       (delay (error))) d))])
-                                                                                                (delay [(lam bs
+                                                                                                (delay [(lam br
                                                                                                     (force (case (constr 0 [l
                                                                                                           [f
                                                                                                             [(builtin unConstrData)
@@ -395,14 +381,14 @@
                                                                                                               y]]]]
                                                                                                       (delay (con unit ()))
                                                                                                       (delay (error))) d))])) d)))
-                                                                                          [(lam bt
+                                                                                          [(lam bs
                                                                                               (force (case (constr 0 [(builtin equalsInteger)
                                                                                                     [b
-                                                                                                      bt]
+                                                                                                      bs]
                                                                                                     (con integer 0)]
                                                                                                   (delay [c
                                                                                                     [f
-                                                                                                      bt]])
+                                                                                                      bs]])
                                                                                                   (delay (error))) d)))
                                                                                             [(builtin unConstrData)
                                                                                               [c
@@ -420,208 +406,208 @@
                                                                       [f
                                                                         [(builtin unConstrData)
                                                                           t]]]))
-                                                                (lam bu
-                                                                  (lam bv
+                                                                (lam bt
+                                                                  (lam bu
                                                                     [(builtin addInteger)
                                                                       (con integer 1)
                                                                       [(builtin divideInteger)
                                                                         [(builtin subtractInteger)
-                                                                          bu
+                                                                          bt
                                                                           (con integer 1)]
-                                                                        bv]]))])
-                                                            (lam bw
-                                                              (lam bx
-                                                                [(lam by
-                                                                    (lam bz
-                                                                      [(lam ca
+                                                                        bu]]))])
+                                                            (lam bv
+                                                              (lam bw
+                                                                [(lam bx
+                                                                    (lam by
+                                                                      [(lam bz
                                                                           (force (case (constr 0 [(builtin equalsInteger)
                                                                                 [b
-                                                                                  ca]
+                                                                                  bz]
                                                                                 (con integer 0)]
                                                                               (delay [(builtin unIData)
-                                                                                [(lam cb
-                                                                                    (lam cc
+                                                                                [(lam ca
+                                                                                    (lam cb
                                                                                       (force (case (constr 0 [(builtin equalsInteger)
                                                                                             [b
-                                                                                              cb]
+                                                                                              ca]
                                                                                             (con integer 0)]
                                                                                           (delay [c
                                                                                             [f
-                                                                                              cb]])
-                                                                                          (delay cc)) d))))
+                                                                                              ca]])
+                                                                                          (delay cb)) d))))
                                                                                   [(builtin unConstrData)
                                                                                     (case (constr 0 [c
                                                                                           [f
-                                                                                            ca]]
+                                                                                            bz]]
                                                                                         [(builtin bData)
-                                                                                          bz]
-                                                                                        (lam cd
-                                                                                          [(lam ce
-                                                                                              (lam cf
+                                                                                          by]
+                                                                                        (lam cc
+                                                                                          [(lam cd
+                                                                                              (lam ce
                                                                                                 [q
-                                                                                                  ce
+                                                                                                  cd
                                                                                                   [(builtin unBData)
-                                                                                                    cf]]))
+                                                                                                    ce]]))
                                                                                             [(builtin unBData)
-                                                                                              cd]])) p)]
+                                                                                              cc]])) p)]
                                                                                   (con data (I 0))]])
                                                                               (delay (con integer 0))) d)))
                                                                         [(builtin unConstrData)
-                                                                          (case (constr 0 bw
-                                                                              by
-                                                                              (lam cg
-                                                                                [(lam ch
-                                                                                    (lam ci
+                                                                          (case (constr 0 bv
+                                                                              bx
+                                                                              (lam cf
+                                                                                [(lam cg
+                                                                                    (lam ch
                                                                                       [q
-                                                                                        ch
+                                                                                        cg
                                                                                         [(builtin unBData)
-                                                                                          ci]]))
+                                                                                          ch]]))
                                                                                   [(builtin unBData)
-                                                                                    cg]])) p)]]))
+                                                                                    cf]])) p)]]))
                                                                   [(builtin bData)
-                                                                    bx]]))])
-                                                        (lam cj
-                                                          (lam ck
+                                                                    bw]]))])
+                                                        (lam ci
+                                                          (lam cj
                                                             (force (case (constr 0 [(builtin lessThanByteString)
-                                                                  cj ck]
+                                                                  ci cj]
                                                                 (delay (con data (Constr 0 [])))
                                                                 (delay (case (constr 0 [(builtin equalsByteString)
-                                                                      cj ck]
+                                                                      ci cj]
                                                                     (con data (Constr 1 []))
                                                                     (con data (Constr 2 []))) d))) d))))])
-                                                    (lam cl
-                                                      (lam cm
-                                                        (lam cn
-                                                          [h (lam co
-                                                              (lam cp
-                                                                (force (case (constr 0 cp
+                                                    (lam ck
+                                                      (lam cl
+                                                        (lam cm
+                                                          [h (lam cn
+                                                              (lam co
+                                                                (force (case (constr 0 co
                                                                     (delay (con data (Constr 1 [])))
-                                                                    (delay [(lam cq
-                                                                        [(lam cr
-                                                                            (force (case (constr 0 [cr
+                                                                    (delay [(lam cp
+                                                                        [(lam cq
+                                                                            (force (case (constr 0 [cq
                                                                                   (con integer 0)]
                                                                                 (delay (con data (Constr 1 [])))
-                                                                                (delay (force (case (constr 0 [cr
+                                                                                (delay (force (case (constr 0 [cq
                                                                                       (con integer 1)]
                                                                                     (delay [(builtin constrData)
                                                                                       (con integer 0)
                                                                                       [e
                                                                                         [f
-                                                                                          cq]
+                                                                                          cp]
                                                                                         (con (list data) [])]])
-                                                                                    (delay [co
+                                                                                    (delay [cn
                                                                                       [g
-                                                                                        cp]])) d)))) d)))
+                                                                                        co]])) d)))) d)))
                                                                           [(builtin equalsInteger)
                                                                             [b
                                                                               [(builtin unConstrData)
-                                                                                [cn
-                                                                                  cm
+                                                                                [cm
+                                                                                  cl
                                                                                   [b
-                                                                                    cq]]]]]])
+                                                                                    cp]]]]]])
                                                                       [c
-                                                                        cp]])) a))))
+                                                                        co]])) a))))
                                                             [(builtin unMapData)
-                                                              cl]])))]) (lam cs
-                                                  (lam ct
-                                                    (case (constr 0 cs
+                                                              ck]])))]) (lam cr
+                                                  (lam cs
+                                                    (case (constr 0 cr
                                                         (con data (List []))
-                                                        (lam cu
-                                                          (lam cv
+                                                        (lam ct
+                                                          (lam cu
                                                             [(builtin listData)
-                                                              [(lam cw
-                                                                  (force (case (constr 0 [ct
-                                                                        cu]
+                                                              [(lam cv
+                                                                  (force (case (constr 0 [cs
+                                                                        ct]
                                                                       (delay [e
-                                                                        cu cw])
-                                                                      (delay cw)) d)))
+                                                                        ct cv])
+                                                                      (delay cv)) d)))
                                                                 [(builtin unListData)
-                                                                  cv]]]))) n)))])
+                                                                  cu]]]))) n)))])
                                             [h (lam n
-                                                (lam cx
-                                                  (lam cy
-                                                    (lam cz
-                                                      (force (case (constr 0 cx
-                                                          (delay cy) (delay [cz
-                                                            [c cx]
+                                                (lam cw
+                                                  (lam cx
+                                                    (lam cy
+                                                      (force (case (constr 0 cw
+                                                          (delay cx) (delay [cy
+                                                            [c cw]
                                                             (case (constr 0 [g
-                                                                  cx] cy
-                                                                cz) n)])) a))))))]])
+                                                                  cw] cx
+                                                                cy) n)])) a))))))]])
                                         [h (lam m
-                                            (lam da
-                                              (lam db
-                                                (lam dc
-                                                  (force (case (constr 0 da
-                                                      (delay db)
+                                            (lam cz
+                                              (lam da
+                                                (lam db
+                                                  (force (case (constr 0 cz
+                                                      (delay da)
                                                       (delay (case (constr 0 [g
-                                                            da] [dc db [c da]]
-                                                          dc) m))) a))))))]])
-                                    (lam dd
-                                      (lam de
-                                        [(lam df
-                                            [(lam dg
+                                                            cz] [db da [c cz]]
+                                                          db) m))) a))))))]])
+                                    (lam dc
+                                      (lam dd
+                                        [(lam de
+                                            [(lam df
                                                 (force (case (constr 0 [(builtin equalsInteger)
-                                                      [b dg] (con integer 1)]
-                                                    (delay [(lam dh
+                                                      [b df] (con integer 1)]
+                                                    (delay [(lam dg
                                                         (force (case (constr 0 (case (constr 0 [(builtin equalsInteger)
                                                                   [b
                                                                     [(builtin unConstrData)
                                                                       [c [g
-                                                                          df]]]]
+                                                                          de]]]]
                                                                   (con integer 0)]
                                                                 (con bool False)
                                                                 (con bool True)) d)
                                                             (delay [(builtin lessThanInteger)
-                                                              de
+                                                              dd
                                                               [(builtin unIData)
-                                                                [c dh]]])
+                                                                [c dg]]])
                                                             (delay [(builtin lessThanEqualsInteger)
-                                                              de
+                                                              dd
                                                               [(builtin unIData)
-                                                                [c dh]]])) d)))
-                                                      [f dg]])
+                                                                [c dg]]])) d)))
+                                                      [f df]])
                                                     (delay (con bool False))) d)))
-                                              [(builtin unConstrData) [c df]]])
+                                              [(builtin unConstrData) [c de]]])
                                           [f [(builtin unConstrData) [c
-                                                dd]]]]))]) (lam di
-                                  [(lam dj
+                                                dc]]]]))]) (lam dh
+                                  [(lam di
                                       (force (case (constr 0 [(builtin equalsInteger)
-                                            [b dj] (con integer 0)]
-                                          (delay [(builtin unBData) [c [f dj]]])
+                                            [b di] (con integer 0)]
+                                          (delay [(builtin unBData) [c [f di]]])
                                           (delay (error))) d)))
                                     [(builtin unConstrData) [c [f
-                                          [(builtin unConstrData) [c di]]]]]])])
-                            (lam dk
-                              (lam dl
+                                          [(builtin unConstrData) [c dh]]]]]])])
+                            (lam dj
+                              (lam dk
                                 (case (constr 0 [(builtin unListData) [c [g [g
-                                            [g [g [g [g [g [g dk]]]]]]]]]]
-                                    [(builtin bData) dl] (lam dm
-                                      [(lam dn
-                                          (lam do
-                                            [(builtin equalsByteString) dn
-                                              [(builtin unBData) do]]))
-                                        [(builtin unBData) dm]])) (lam dp
-                                    (lam dq
-                                      (lam dr
+                                            [g [g [g [g [g [g dj]]]]]]]]]]
+                                    [(builtin bData) dk] (lam dl
+                                      [(lam dm
+                                          (lam dn
+                                            [(builtin equalsByteString) dm
+                                              [(builtin unBData) dn]]))
+                                        [(builtin unBData) dl]])) (lam do
+                                    (lam dp
+                                      (lam dq
                                         (case (constr 0 (case (constr 0 [(builtin equalsInteger)
                                                   [b [(builtin unConstrData) [i
-                                                        dp (lam ds
+                                                        do (lam dr
                                                           [(builtin equalsData)
-                                                            ds dq])]]]
+                                                            dr dp])]]]
                                                   (con integer 0)]
                                                 (con bool False)
                                                 (con bool True)) d)
                                             (con bool False)
                                             (con bool True)) d)))))))]) [h
                           (lam i
-                            (lam dt
-                              (lam du
-                                (force (case (constr 0 dt
+                            (lam ds
+                              (lam dt
+                                (force (case (constr 0 ds
                                     (delay (con data (Constr 1 [])))
-                                    (delay (force (case (constr 0 [du [c dt]]
+                                    (delay (force (case (constr 0 [dt [c ds]]
                                         (delay [(builtin constrData)
-                                          (con integer 0) [e [c dt]
+                                          (con integer 0) [e [c ds]
                                             (con (list data) [])]]) (delay [i [g
-                                            dt] du])) d)))) a)))))]]) (lam dv
-                      [(lam dw [dv (lam dx [dw dw dx])]) (lam dw
-                          [dv (lam dx [dw dw dx])])])])))))))))
+                                            ds] dt])) d)))) a)))))]]) (lam du
+                      [(lam dv [du (lam dw [dv dv dw])]) (lam dv
+                          [du (lam dw [dv dv dw])])])])))))))))


### PR DESCRIPTION
Adds the Scalus implementation of the UPLC-CAPE `linear_vesting` scenario. This PR carries the mainnet (changPV) build; the preview (van Rossem) build follows in a separate PR.

It is a `Data -> Unit` spending validator releasing a native asset on an installment schedule. The redeemer is a nullary constructor (`Constr 0 []` = PartialUnlock, `Constr 1 []` = FullUnlock); all parameters live in the datum. Partial unlock enforces the `divCeil` schedule, datum preservation and a single-script-input guard against double satisfaction, and treats the first script output as the continuing UTxO.

Measured against the scenario's `cape-tests.json` with the UPLC-CAPE evaluator, all 29 evaluations match their expected outcomes. The mainnet build is 1,403 bytes, with per-evaluation CPU peaking at 69,552,166 and memory at 196,532 units.

Also wires the scenario into `build-scalus` and documents it in CLAUDE.md.
